### PR TITLE
Add consumer blocking context parameter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 sudo: false
 language: scala
 
+services:
+  - docker
+
 scala:
   - 2.12.8
 

--- a/core/src/main/scala/com/banno/kafka/consumer/ConsumerApi.scala
+++ b/core/src/main/scala/com/banno/kafka/consumer/ConsumerApi.scala
@@ -205,6 +205,14 @@ object ConsumerApi {
     avro4s[F, K, V](configs: _*).map(ShiftingConsumerImpl(_, blockingContext))
 
   def resourceAvro4sShifting[F[_]: Async: ContextShift, K: FromRecord, V: FromRecord](
+      configs: (String, AnyRef)*
+  ): Resource[F, ConsumerApi[F, K, V]] =
+    defaultBlockingContext.flatMap(
+      blockingContext =>
+        resourceAvro4s[F, K, V](configs: _*).map(ShiftingConsumerImpl(_, blockingContext))
+    )
+
+  def resourceAvro4sShiftingWithContext[F[_]: Async: ContextShift, K: FromRecord, V: FromRecord](
       blockingContext: ExecutionContext,
       configs: (String, AnyRef)*
   ): Resource[F, ConsumerApi[F, K, V]] =

--- a/core/src/main/scala/com/banno/kafka/consumer/ShiftingConsumerImpl.scala
+++ b/core/src/main/scala/com/banno/kafka/consumer/ShiftingConsumerImpl.scala
@@ -17,7 +17,6 @@
 package com.banno.kafka.consumer
 
 import cats.effect.{Async, ContextShift}
-import java.util.concurrent.Executors
 import java.util.regex.Pattern
 
 import scala.concurrent.duration._
@@ -26,83 +25,82 @@ import org.apache.kafka.clients.consumer._
 
 import scala.concurrent.ExecutionContext
 
-case class ShiftingConsumerImpl[F[_]: Async, K, V](c: ConsumerApi[F, K, V])(
-    implicit CS: ContextShift[F]
-) extends ConsumerApi[F, K, V] {
-  val consumerContext: ExecutionContext =
-    ExecutionContext.fromExecutorService(Executors.newFixedThreadPool(1))
-
+case class ShiftingConsumerImpl[F[_]: Async, K, V](
+    c: ConsumerApi[F, K, V],
+    blockingContext: ExecutionContext
+)(implicit CS: ContextShift[F])
+    extends ConsumerApi[F, K, V] {
   def assign(partitions: Iterable[TopicPartition]): F[Unit] =
-    CS.evalOn(consumerContext)(c.assign(partitions))
-  def assignment: F[Set[TopicPartition]] = CS.evalOn(consumerContext)(c.assignment)
+    CS.evalOn(blockingContext)(c.assign(partitions))
+  def assignment: F[Set[TopicPartition]] = CS.evalOn(blockingContext)(c.assignment)
   def beginningOffsets(partitions: Iterable[TopicPartition]): F[Map[TopicPartition, Long]] =
-    CS.evalOn(consumerContext)(c.beginningOffsets(partitions))
+    CS.evalOn(blockingContext)(c.beginningOffsets(partitions))
   def beginningOffsets(
       partitions: Iterable[TopicPartition],
       timeout: FiniteDuration
   ): F[Map[TopicPartition, Long]] =
-    CS.evalOn(consumerContext)(c.beginningOffsets(partitions, timeout))
-  def close: F[Unit] = CS.evalOn(consumerContext)(c.close)
-  def close(timeout: FiniteDuration): F[Unit] = CS.evalOn(consumerContext)(c.close(timeout))
-  def commitAsync: F[Unit] = CS.evalOn(consumerContext)(c.commitAsync)
+    CS.evalOn(blockingContext)(c.beginningOffsets(partitions, timeout))
+  def close: F[Unit] = CS.evalOn(blockingContext)(c.close)
+  def close(timeout: FiniteDuration): F[Unit] = CS.evalOn(blockingContext)(c.close(timeout))
+  def commitAsync: F[Unit] = CS.evalOn(blockingContext)(c.commitAsync)
   def commitAsync(
       offsets: Map[TopicPartition, OffsetAndMetadata],
       callback: OffsetCommitCallback
   ): F[Unit] =
-    CS.evalOn(consumerContext)(c.commitAsync(offsets, callback))
+    CS.evalOn(blockingContext)(c.commitAsync(offsets, callback))
   def commitAsync(callback: OffsetCommitCallback): F[Unit] =
-    CS.evalOn(consumerContext)(c.commitAsync(callback))
-  def commitSync: F[Unit] = CS.evalOn(consumerContext)(c.commitSync)
+    CS.evalOn(blockingContext)(c.commitAsync(callback))
+  def commitSync: F[Unit] = CS.evalOn(blockingContext)(c.commitSync)
   def commitSync(offsets: Map[TopicPartition, OffsetAndMetadata]): F[Unit] =
-    CS.evalOn(consumerContext)(c.commitSync(offsets))
+    CS.evalOn(blockingContext)(c.commitSync(offsets))
   def committed(partition: TopicPartition): F[OffsetAndMetadata] =
-    CS.evalOn(consumerContext)(c.committed(partition))
+    CS.evalOn(blockingContext)(c.committed(partition))
   def endOffsets(partitions: Iterable[TopicPartition]): F[Map[TopicPartition, Long]] =
-    CS.evalOn(consumerContext)(c.endOffsets(partitions))
+    CS.evalOn(blockingContext)(c.endOffsets(partitions))
   def endOffsets(
       partitions: Iterable[TopicPartition],
       timeout: FiniteDuration
   ): F[Map[TopicPartition, Long]] =
-    CS.evalOn(consumerContext)(c.endOffsets(partitions, timeout))
-  def listTopics: F[Map[String, Seq[PartitionInfo]]] = CS.evalOn(consumerContext)(c.listTopics)
+    CS.evalOn(blockingContext)(c.endOffsets(partitions, timeout))
+  def listTopics: F[Map[String, Seq[PartitionInfo]]] = CS.evalOn(blockingContext)(c.listTopics)
   def listTopics(timeout: FiniteDuration): F[Map[String, Seq[PartitionInfo]]] =
-    CS.evalOn(consumerContext)(c.listTopics(timeout))
-  def metrics: F[Map[MetricName, Metric]] = CS.evalOn(consumerContext)(c.metrics)
+    CS.evalOn(blockingContext)(c.listTopics(timeout))
+  def metrics: F[Map[MetricName, Metric]] = CS.evalOn(blockingContext)(c.metrics)
   def offsetsForTimes(
       timestampsToSearch: Map[TopicPartition, Long]
   ): F[Map[TopicPartition, OffsetAndTimestamp]] =
-    CS.evalOn(consumerContext)(c.offsetsForTimes(timestampsToSearch))
+    CS.evalOn(blockingContext)(c.offsetsForTimes(timestampsToSearch))
   def offsetsForTimes(
       timestampsToSearch: Map[TopicPartition, Long],
       timeout: FiniteDuration
   ): F[Map[TopicPartition, OffsetAndTimestamp]] =
-    CS.evalOn(consumerContext)(c.offsetsForTimes(timestampsToSearch, timeout))
+    CS.evalOn(blockingContext)(c.offsetsForTimes(timestampsToSearch, timeout))
   def partitionsFor(topic: String): F[Seq[PartitionInfo]] =
-    CS.evalOn(consumerContext)(c.partitionsFor(topic))
+    CS.evalOn(blockingContext)(c.partitionsFor(topic))
   def partitionsFor(topic: String, timeout: FiniteDuration): F[Seq[PartitionInfo]] =
-    CS.evalOn(consumerContext)(c.partitionsFor(topic, timeout))
+    CS.evalOn(blockingContext)(c.partitionsFor(topic, timeout))
   def pause(partitions: Iterable[TopicPartition]): F[Unit] =
-    CS.evalOn(consumerContext)(c.pause(partitions))
-  def paused: F[Set[TopicPartition]] = CS.evalOn(consumerContext)(c.paused)
+    CS.evalOn(blockingContext)(c.pause(partitions))
+  def paused: F[Set[TopicPartition]] = CS.evalOn(blockingContext)(c.paused)
   def poll(timeout: FiniteDuration): F[ConsumerRecords[K, V]] =
-    CS.evalOn(consumerContext)(c.poll(timeout))
+    CS.evalOn(blockingContext)(c.poll(timeout))
   def position(partition: TopicPartition): F[Long] =
-    CS.evalOn(consumerContext)(c.position(partition))
+    CS.evalOn(blockingContext)(c.position(partition))
   def resume(partitions: Iterable[TopicPartition]): F[Unit] =
-    CS.evalOn(consumerContext)(c.resume(partitions))
+    CS.evalOn(blockingContext)(c.resume(partitions))
   def seek(partition: TopicPartition, offset: Long): F[Unit] =
-    CS.evalOn(consumerContext)(c.seek(partition, offset))
+    CS.evalOn(blockingContext)(c.seek(partition, offset))
   def seekToBeginning(partitions: Iterable[TopicPartition]): F[Unit] =
-    CS.evalOn(consumerContext)(c.seekToBeginning(partitions))
+    CS.evalOn(blockingContext)(c.seekToBeginning(partitions))
   def seekToEnd(partitions: Iterable[TopicPartition]): F[Unit] =
-    CS.evalOn(consumerContext)(c.seekToEnd(partitions))
-  def subscribe(topics: Iterable[String]): F[Unit] = CS.evalOn(consumerContext)(c.subscribe(topics))
+    CS.evalOn(blockingContext)(c.seekToEnd(partitions))
+  def subscribe(topics: Iterable[String]): F[Unit] = CS.evalOn(blockingContext)(c.subscribe(topics))
   def subscribe(topics: Iterable[String], callback: ConsumerRebalanceListener): F[Unit] =
-    CS.evalOn(consumerContext)(c.subscribe(topics, callback))
-  def subscribe(pattern: Pattern): F[Unit] = CS.evalOn(consumerContext)(c.subscribe(pattern))
+    CS.evalOn(blockingContext)(c.subscribe(topics, callback))
+  def subscribe(pattern: Pattern): F[Unit] = CS.evalOn(blockingContext)(c.subscribe(pattern))
   def subscribe(pattern: Pattern, callback: ConsumerRebalanceListener): F[Unit] =
-    CS.evalOn(consumerContext)(c.subscribe(pattern, callback))
-  def subscription: F[Set[String]] = CS.evalOn(consumerContext)(c.subscription)
-  def unsubscribe: F[Unit] = CS.evalOn(consumerContext)(c.unsubscribe)
-  def wakeup: F[Unit] = CS.evalOn(consumerContext)(c.wakeup)
+    CS.evalOn(blockingContext)(c.subscribe(pattern, callback))
+  def subscription: F[Set[String]] = CS.evalOn(blockingContext)(c.subscription)
+  def unsubscribe: F[Unit] = CS.evalOn(blockingContext)(c.unsubscribe)
+  def wakeup: F[Unit] = CS.evalOn(blockingContext)(c.wakeup)
 }

--- a/core/src/main/scala/com/banno/kafka/producer/ProducerApi.scala
+++ b/core/src/main/scala/com/banno/kafka/producer/ProducerApi.scala
@@ -192,10 +192,18 @@ object ProducerApi {
     avro4s[F, K, V](configs: _*).map(ShiftingProducerImpl[F, K, V](_, producerContext))
 
   def resourceAvro4sShifting[F[_]: Async: ContextShift, K: ToRecord, V: ToRecord](
-      producerContext: ExecutionContext,
       configs: (String, AnyRef)*
   ): Resource[F, ProducerApi[F, K, V]] =
-    resourceAvro4s[F, K, V](configs: _*).map(ShiftingProducerImpl[F, K, V](_, producerContext))
+    defaultBlockingContext.flatMap(
+      blockingContext =>
+        resourceAvro4s[F, K, V](configs: _*).map(ShiftingProducerImpl[F, K, V](_, blockingContext))
+    )
+
+  def resourceAvro4sShiftingWithContext[F[_]: Async: ContextShift, K: ToRecord, V: ToRecord](
+      blockingContext: ExecutionContext,
+      configs: (String, AnyRef)*
+  ): Resource[F, ProducerApi[F, K, V]] =
+    resourceAvro4s[F, K, V](configs: _*).map(ShiftingProducerImpl[F, K, V](_, blockingContext))
 
   def defaultBlockingContext[F[_]: Sync] =
     Resource.make(

--- a/core/src/test/scala/com/banno/kafka/ConsumerAndProducerApiSpec.scala
+++ b/core/src/test/scala/com/banno/kafka/ConsumerAndProducerApiSpec.scala
@@ -31,6 +31,7 @@ class ConsumerAndProducerApiSpec
     with Matchers
     with InMemoryKafka {
   val producerContext = ExecutionContext.fromExecutorService(Executors.newFixedThreadPool(2))
+  val consumerContext = ExecutionContext.fromExecutorService(Executors.newFixedThreadPool(2))
   implicit val defaultContextShift = IO.contextShift(ExecutionContext.global)
   implicit val defaultConcurrent = IO.ioConcurrentEffect(defaultContextShift)
   implicit val defaultTimer = IO.timer(ExecutionContext.global)
@@ -181,6 +182,7 @@ class ConsumerAndProducerApiSpec
           BootstrapServers(bootstrapServer)
         )
         c <- ConsumerApi.createShifting[IO, Int, String](
+          consumerContext,
           BootstrapServers(bootstrapServer),
           GroupId(groupId),
           AutoOffsetReset.earliest

--- a/examples/src/main/scala/example1/ExampleApp.scala
+++ b/examples/src/main/scala/example1/ExampleApp.scala
@@ -66,15 +66,24 @@ final class ExampleApp[F[_]: Async: ContextShift] {
         )(_.close)
     )
 
-  val consumerResource = Resource.make(
-    ConsumerApi.avro4sShifting[F, CustomerId, Customer](
-      BootstrapServers(kafkaBootstrapServers),
-      SchemaRegistryUrl(schemaRegistryUri),
-      ClientId("consumer-example"),
-      GroupId("consumer-example-group"),
-      EnableAutoCommit(false)
+  val consumerThreadPoolResource = Resource.make(
+    Sync[F].delay(ExecutionContext.fromExecutorService(Executors.newFixedThreadPool(1)))
+  )(a => Sync[F].delay(a.shutdown()))
+
+  val consumerResource =
+    producerThreadPoolResource.flatMap(
+      consumerPool =>
+        Resource.make(
+          ConsumerApi.avro4sShifting[F, CustomerId, Customer](
+            consumerPool,
+            BootstrapServers(kafkaBootstrapServers),
+            SchemaRegistryUrl(schemaRegistryUri),
+            ClientId("consumer-example"),
+            GroupId("consumer-example-group"),
+            EnableAutoCommit(false)
+          )
+        )(_.close)
     )
-  )(_.close)
 
   val example: F[Unit] =
     for {

--- a/examples/src/main/scala/example2/ExampleApp.scala
+++ b/examples/src/main/scala/example2/ExampleApp.scala
@@ -54,26 +54,20 @@ final class ExampleApp[F[_]: Async: ContextShift] {
     )
     .toVector
 
-  val producer = ProducerApi.defaultBlockingContext
-    .flatMap(
-      ProducerApi.resourceAvro4sShifting[F, CustomerId, Customer](
-        _,
-        BootstrapServers(kafkaBootstrapServers),
-        SchemaRegistryUrl(schemaRegistryUri),
-        ClientId("producer-example")
-      )
+  val producer =
+    ProducerApi.resourceAvro4sShifting[F, CustomerId, Customer](
+      BootstrapServers(kafkaBootstrapServers),
+      SchemaRegistryUrl(schemaRegistryUri),
+      ClientId("producer-example")
     )
 
-  val consumer = ConsumerApi.defaultBlockingContext
-    .flatMap(
-      ConsumerApi.resourceAvro4sShifting[F, CustomerId, Customer](
-        _,
-        BootstrapServers(kafkaBootstrapServers),
-        SchemaRegistryUrl(schemaRegistryUri),
-        ClientId("consumer-example"),
-        GroupId("consumer-example-group"),
-        EnableAutoCommit(false)
-      )
+  val consumer =
+    ConsumerApi.resourceAvro4sShifting[F, CustomerId, Customer](
+      BootstrapServers(kafkaBootstrapServers),
+      SchemaRegistryUrl(schemaRegistryUri),
+      ClientId("consumer-example"),
+      GroupId("consumer-example-group"),
+      EnableAutoCommit(false)
     )
 
   val example: F[Unit] =

--- a/examples/src/main/scala/example2/ExampleApp.scala
+++ b/examples/src/main/scala/example2/ExampleApp.scala
@@ -64,13 +64,17 @@ final class ExampleApp[F[_]: Async: ContextShift] {
       )
     )
 
-  val consumer = ConsumerApi.resourceAvro4sShifting[F, CustomerId, Customer](
-    BootstrapServers(kafkaBootstrapServers),
-    SchemaRegistryUrl(schemaRegistryUri),
-    ClientId("consumer-example"),
-    GroupId("consumer-example-group"),
-    EnableAutoCommit(false)
-  )
+  val consumer = ConsumerApi.defaultBlockingContext
+    .flatMap(
+      ConsumerApi.resourceAvro4sShifting[F, CustomerId, Customer](
+        _,
+        BootstrapServers(kafkaBootstrapServers),
+        SchemaRegistryUrl(schemaRegistryUri),
+        ClientId("consumer-example"),
+        GroupId("consumer-example-group"),
+        EnableAutoCommit(false)
+      )
+    )
 
   val example: F[Unit] =
     for {

--- a/project/travis-before-build.sh
+++ b/project/travis-before-build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -xe
+
+cd `dirname $0`/..
+
+docker-compose -f docker-compose.yml up -d


### PR DESCRIPTION
Allows users to pass a blocking context of their choosing, and provides a default context Resource. We might ultimately want additional convenience functions on top of these, but I think this is a good start.