### PR TITLE
Ignore avro4s updates for now

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,1 +1,6 @@
-updates.ignore = []
+updates.ignore = [
+  {
+    groupId = "com.sksamuel.avro4s",
+    artifactId = "avro4s-core"
+  }
+]


### PR DESCRIPTION
We'll target avro4s 3.0.0 once it's released, so ignoring the minor version bump for now.