### PR TITLE
Only return Resource/Stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,26 +18,38 @@ libraryDependencies ++= Seq(
 Sending records to Kafka is an effect. If we wanted to periodically write random integers to a Kafka topic, we could do:
 
 ```scala
-Stream
-  .awakeDelay[F](1 second)
-  .evalMap(
-    _ =>
-      Sync[F]
-        .delay(Random.nextInt())
-        .flatMap(i => producer.sendAndForget(new ProducerRecord(topic, i, i)))
+ProducerApi
+  .stream[F, Int, Int](BootstrapServers(kafkaBootstrapServers))
+  .flatMap(
+    p =>
+      Stream
+        .awakeDelay[F](1 second)
+        .evalMap(
+          _ =>
+            Sync[F]
+              .delay(Random.nextInt())
+              .flatMap(i => p.sendAndForget(new ProducerRecord(topic.name, i, i)))
+        )
   )
 ```
 
 Polling Kafka for records is also an effect, and we can obtain a stream of records from a topic. We can print the even random integers from the above topic using:
 
 ```scala
-consumer.recordStream(
-    initialize = consumer.subscribe(topic),
-    pollTimeout = 1.second
+ConsumerApi
+  .stream[F, Int, Int](
+    BootstrapServers(kafkaBootstrapServers),
+    GroupId("example3"),
+    AutoOffsetReset.earliest,
+    EnableAutoCommit(true)
   )
-  .map(_.value)
-  .filter(_ % 2 == 0)
-  .evalMap(i => Sync[F].delay(println(i)))
+  .evalTap(_.subscribe(topic.name))
+  .flatMap(
+    _.recordStream(1.second)
+      .map(_.value)
+      .filter(_ % 2 == 0)
+      .evalMap(i => Sync[F].delay(println(i)))
+  )
 ```
 
 ## Learning more

--- a/core/src/main/scala/com/banno/kafka/admin/AdminApi.scala
+++ b/core/src/main/scala/com/banno/kafka/admin/AdminApi.scala
@@ -17,7 +17,7 @@
 package com.banno.kafka.admin
 
 import cats.implicits._
-import cats.effect.{Sync, Resource}
+import cats.effect.{Resource, Sync}
 import fs2.Stream
 import org.apache.kafka.common.TopicPartitionReplica
 import org.apache.kafka.common.config.ConfigResource
@@ -118,14 +118,14 @@ object AdminApi {
     Resource.make(createClient[F](configs).map(AdminImpl.create[F](_)))(_.close)
   def resource[F[_]: Sync](configs: Properties): Resource[F, AdminApi[F]] =
     Resource.make(createClient[F](configs).map(AdminImpl.create[F](_)))(_.close)
-  def resource[F[_]: Sync](configs: (String, AnyRef)*): Resource[F, AdminApi[F]] = 
+  def resource[F[_]: Sync](configs: (String, AnyRef)*): Resource[F, AdminApi[F]] =
     resource[F](configs.toMap)
 
   def stream[F[_]: Sync](configs: Map[String, AnyRef]): Stream[F, AdminApi[F]] =
     Stream.resource(resource[F](configs))
   def stream[F[_]: Sync](configs: Properties): Stream[F, AdminApi[F]] =
     Stream.resource(resource[F](configs))
-  def stream[F[_]: Sync](configs: (String, AnyRef)*): Stream[F, AdminApi[F]] = 
+  def stream[F[_]: Sync](configs: (String, AnyRef)*): Stream[F, AdminApi[F]] =
     stream[F](configs.toMap)
 
   def createTopicsIdempotent[F[_]: Sync](

--- a/core/src/main/scala/com/banno/kafka/admin/AdminImpl.scala
+++ b/core/src/main/scala/com/banno/kafka/admin/AdminImpl.scala
@@ -115,3 +115,7 @@ case class AdminImpl[F[_]](a: AdminClient)(implicit F: Sync[F]) extends AdminApi
   def listTopics: F[ListTopicsResult] = F.delay(a.listTopics())
   def listTopics(options: ListTopicsOptions): F[ListTopicsResult] = F.delay(a.listTopics(options))
 }
+
+object AdminImpl {
+  def create[F[_]: Sync](a: AdminClient): AdminApi[F] = AdminImpl[F](a)
+}

--- a/core/src/main/scala/com/banno/kafka/consumer/ConsumerImpl.scala
+++ b/core/src/main/scala/com/banno/kafka/consumer/ConsumerImpl.scala
@@ -134,3 +134,11 @@ case class ConsumerImpl[F[_], K, V](c: Consumer[K, V])(implicit F: Sync[F])
   def unsubscribe: F[Unit] = F.delay(c.unsubscribe())
   def wakeup: F[Unit] = F.delay(c.wakeup())
 }
+
+object ConsumerImpl {
+  //returns the type expected when creating a Resource
+  def create[F[_]: Sync, K, V](
+      c: Consumer[K, V]
+  ): ConsumerApi[F, K, V] =
+    ConsumerImpl(c)
+}

--- a/core/src/main/scala/com/banno/kafka/producer/ProducerImpl.scala
+++ b/core/src/main/scala/com/banno/kafka/producer/ProducerImpl.scala
@@ -88,3 +88,11 @@ case class ProducerImpl[F[_], K, V](p: Producer[K, V])(implicit F: Async[F])
   def sendAsync(record: ProducerRecord[K, V]): F[RecordMetadata] =
     F.async(sendRaw(record, _))
 }
+
+object ProducerImpl {
+  //returns the type expected when creating a Resource
+  def create[F[_]: Async, K, V](
+      p: Producer[K, V]
+  ): ProducerApi[F, K, V] =
+    ProducerImpl(p)
+}

--- a/core/src/test/scala/com/banno/kafka/AdminApiSpec.scala
+++ b/core/src/test/scala/com/banno/kafka/AdminApiSpec.scala
@@ -19,14 +19,9 @@ class AdminApiSpec extends FlatSpec with Matchers with InMemoryKafka {
         _ <- admin.createTopicsIdempotent(List(new NewTopic("test1", 1, 1)))
         ltr2 <- admin.listTopics
         ns2 <- F.delay(ltr2.names.get())
-        _ <- admin.close
       } yield (ns1, ns2)
 
-    val io = for {
-      admin <- AdminApi[IO](BootstrapServers(bootstrapServer))
-      results <- program(admin)
-    } yield results
-    val (before, after) = io.unsafeRunSync()
+    val (before, after) = AdminApi.resource[IO](BootstrapServers(bootstrapServer)).use(program[IO]).unsafeRunSync()
     before should not contain ("test1")
     after should contain("test1")
   }

--- a/core/src/test/scala/com/banno/kafka/AdminApiSpec.scala
+++ b/core/src/test/scala/com/banno/kafka/AdminApiSpec.scala
@@ -21,7 +21,8 @@ class AdminApiSpec extends FlatSpec with Matchers with InMemoryKafka {
         ns2 <- F.delay(ltr2.names.get())
       } yield (ns1, ns2)
 
-    val (before, after) = AdminApi.resource[IO](BootstrapServers(bootstrapServer)).use(program[IO]).unsafeRunSync()
+    val (before, after) =
+      AdminApi.resource[IO](BootstrapServers(bootstrapServer)).use(program[IO]).unsafeRunSync()
     before should not contain ("test1")
     after should contain("test1")
   }

--- a/docs/src/main/tut/docs/index.md
+++ b/docs/src/main/tut/docs/index.md
@@ -99,7 +99,7 @@ val producer = ProducerApi.Avro.Generic.resource[IO](
   BootstrapServers(kafkaBootstrapServers),
   SchemaRegistryUrl(schemaRegistryUri),
   ClientId("producer-example")
-).unsafeRunSync
+)
 ```
 
 And we'll define some customer records to be written:

--- a/docs/src/main/tut/docs/index.md
+++ b/docs/src/main/tut/docs/index.md
@@ -95,7 +95,7 @@ import com.banno.kafka.producer._
 Now we can create our producer instance:
 
 ```tut
-val producer = ProducerApi.Avro.Generic.create[IO](
+val producer = ProducerApi.Avro.Generic.resource[IO](
   BootstrapServers(kafkaBootstrapServers),
   SchemaRegistryUrl(schemaRegistryUri),
   ClientId("producer-example")
@@ -112,7 +112,7 @@ val recordsToBeWritten = (1 to 10).map(a => new ProducerRecord(topicName, Custom
 And now we can (attempt to) write our records to Kafka:
 
 ```tut:fail
-recordsToBeWritten.traverse_(producer.sendSync)
+producer.use(p => recordsToBeWritten.traverse_(p.sendSync))
 ```
 
 The above fails to compile, however! Our producer writes generic
@@ -125,13 +125,13 @@ topic. For this, we can use Kafka4s' `avro4s` integration!
 Turning a generic producer into a typed producer is as simple as the following:
 
 ```tut
-val avro4sProducer = producer.toAvro4s[CustomerId, Customer]
+val avro4sProducer = producer.map(_.toAvro4s[CustomerId, Customer])
 ```
 
 We can now write our typed customer records successfully!
 
 ```tut
-recordsToBeWritten.traverse_(r => avro4sProducer.sendSync(r).flatMap(rmd => IO(println(s"Wrote record to ${rmd}")))).unsafeRunSync
+avro4sProducer.use(p => recordsToBeWritten.traverse_(r => p.sendSync(r).flatMap(rmd => IO(println(s"Wrote record to ${rmd}"))))).unsafeRunSync
 ```
 
 ### Read our records from Kafka
@@ -157,34 +157,21 @@ implicit val CS = IO.contextShift(ExecutionContext.global)
 And here's our consumer, which is using Avro4s to deserialize the records:
 
 ```tut
-val (consumer, ctx) = ConsumerApi.Avro4s.create[IO, CustomerId, Customer](
+val consumer = ConsumerApi.Avro4s.resource[IO, CustomerId, Customer](
   BootstrapServers(kafkaBootstrapServers), 
   SchemaRegistryUrl(schemaRegistryUri),
   ClientId("consumer-example"),
   GroupId("consumer-example-group")
-).unsafeRunSync
+)
 ```
 
-With our Kafka consumer in hand, we'll assign to our consumer our topic partition, with no offsets, so that it starts reading from the first record.
+With our Kafka consumer in hand, we'll assign to our consumer our topic partition, with no offsets, so that it starts reading from the first record, and read a stream of records from our Kafka topic:
 ```tut
 import org.apache.kafka.common.TopicPartition
 val initialOffsets = Map.empty[TopicPartition, Long] // Start from beginning
-consumer.assign(topicName, initialOffsets).unsafeRunSync
+val messages = consumer.use(c => c.assign(topicName, initialOffsets) *> c.recordStream(1.second).take(5).compile.toVector).unsafeRunSync
 ```
 
-And we can now read a stream of records from our Kafka topic:
-
-```tut
-val messages = consumer.recordStream(1.second).take(5).compile.toVector.unsafeRunSync
-```
-
-To clean up after ourselves, we'll close and shut down our resources:
-```tut
-consumer.close.unsafeRunSync
-producer.close.unsafeRunSync
-ctx.shutdown()
-```
-
-Note that kafka4s provides constructors that return `cats.effect.Resource`s for the above resources, so that their shutdown steps are guaranteed to run after use. We're manually shutting down resources simply for the sake of example.
+Because the producer and consumer above were created within a `Resource` context, everything was closed and shut down properly.
 
 Now that we've seen a quick overview, we can take a look at more in-depth documentation of Kafka4s utilities.


### PR DESCRIPTION
Resolves #44. Constructors for the following things that need to be closed now only return Resource/Stream:
- `ConsumerApi`
- `ProducerApi`
- `AdminApi`

There is no close operation on the underlying `SchemaRegistryClient`, so `SchemaRegistryApi` does not return in Resource/Stream.