### PR TITLE
Removing stream constructor from ProducerApi and ConsumerApi

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,30 +18,26 @@ libraryDependencies ++= Seq(
 Sending records to Kafka is an effect. If we wanted to periodically write random integers to a Kafka topic, we could do:
 
 ```scala
-ProducerApi
-  .stream[F, Int, Int](BootstrapServers(kafkaBootstrapServers))
-  .flatMap(
-    p =>
-      Stream
-        .awakeDelay[F](1 second)
-        .evalMap(
-          _ =>
-            Sync[F]
-              .delay(Random.nextInt())
-              .flatMap(i => p.sendAndForget(new ProducerRecord(topic.name, i, i)))
-        )
-  )
+ProducerApi.resource[F, Int, Int](BootstrapServers(kafkaBootstrapServers))
+  .map(p =>
+    Timer[F].sleep(1 second).flatMap(_ =>
+      Sync[F].delay(Random.nextInt()).flatMap(
+        i => p.sendAndForget(new ProducerRecord(topic.name, i, i)))
+    )
+  ))
 ```
 
 Polling Kafka for records is also an effect, and we can obtain a stream of records from a topic. We can print the even random integers from the above topic using:
 
 ```scala
-ConsumerApi
-  .stream[F, Int, Int](
-    BootstrapServers(kafkaBootstrapServers),
-    GroupId("example3"),
-    AutoOffsetReset.earliest,
-    EnableAutoCommit(true)
+Stream.resource(
+   ConsumerApi
+      .resource[F, Int, Int](
+        BootstrapServers(kafkaBootstrapServers),
+        GroupId("example3"),
+        AutoOffsetReset.earliest,
+        EnableAutoCommit(true)
+      )
   )
   .evalTap(_.subscribe(topic.name))
   .flatMap(

--- a/README.md
+++ b/README.md
@@ -19,13 +19,19 @@ Sending records to Kafka is an effect. If we wanted to periodically write random
 
 ```scala
 Stream.resource(
-   ProducerApi.resource[F, Int, Int](BootstrapServers(kafkaBootstrapServers))
-  .map(p =>
-    Timer[F].sleep(1 second).flatMap(_ =>
-      Sync[F].delay(Random.nextInt()).flatMap(
-        i => p.sendAndForget(new ProducerRecord(topic.name, i, i)))
-    )
-  ))
+ProducerApi
+  .resource[F, Int, Int](BootstrapServers(kafkaBootstrapServers))
+  .map(
+    p =>
+      Timer[F]
+        .sleep(1 second)
+        .flatMap(
+          _ =>
+            Sync[F]
+              .delay(Random.nextInt())
+              .flatMap(i => p.sendAndForget(new ProducerRecord(topic.name, i, i)))
+        )
+  )
 )
 ```
 

--- a/README.md
+++ b/README.md
@@ -18,13 +18,15 @@ libraryDependencies ++= Seq(
 Sending records to Kafka is an effect. If we wanted to periodically write random integers to a Kafka topic, we could do:
 
 ```scala
-ProducerApi.resource[F, Int, Int](BootstrapServers(kafkaBootstrapServers))
+Stream.resource(
+   ProducerApi.resource[F, Int, Int](BootstrapServers(kafkaBootstrapServers))
   .map(p =>
     Timer[F].sleep(1 second).flatMap(_ =>
       Sync[F].delay(Random.nextInt()).flatMap(
         i => p.sendAndForget(new ProducerRecord(topic.name, i, i)))
     )
   ))
+)
 ```
 
 Polling Kafka for records is also an effect, and we can obtain a stream of records from a topic. We can print the even random integers from the above topic using:

--- a/core/src/main/scala/com/banno/kafka/consumer/ConsumerApi.scala
+++ b/core/src/main/scala/com/banno/kafka/consumer/ConsumerApi.scala
@@ -152,7 +152,6 @@ object ConsumerApi {
           )(_.close)
       )
 
-
     object Generic {
 
       def resource[F[_]: Async: ContextShift](

--- a/core/src/main/scala/com/banno/kafka/consumer/ConsumerApi.scala
+++ b/core/src/main/scala/com/banno/kafka/consumer/ConsumerApi.scala
@@ -134,18 +134,6 @@ object ConsumerApi {
   ): Resource[F, ConsumerApi[F, K, V]] =
     resource[F, K, V](implicitly[Deserializer[K]], implicitly[Deserializer[V]], configs: _*)
 
-  def stream[F[_]: Async: ContextShift, K, V](
-      keyDeserializer: Deserializer[K],
-      valueDeserializer: Deserializer[V],
-      configs: (String, AnyRef)*
-  ): Stream[F, ConsumerApi[F, K, V]] =
-    Stream.resource(resource[F, K, V](keyDeserializer, valueDeserializer, configs: _*))
-
-  def stream[F[_]: Async: ContextShift, K: Deserializer, V: Deserializer](
-      configs: (String, AnyRef)*
-  ): Stream[F, ConsumerApi[F, K, V]] =
-    stream[F, K, V](implicitly[Deserializer[K]], implicitly[Deserializer[V]], configs: _*)
-
   object Avro {
 
     def resource[F[_]: Async: ContextShift, K, V](
@@ -164,10 +152,6 @@ object ConsumerApi {
           )(_.close)
       )
 
-    def stream[F[_]: Async: ContextShift, K, V](
-        configs: (String, AnyRef)*
-    ): Stream[F, ConsumerApi[F, K, V]] =
-      Stream.resource(resource[F, K, V](configs: _*))
 
     object Generic {
 
@@ -188,11 +172,6 @@ object ConsumerApi {
           configs: (String, AnyRef)*
       ): Resource[F, ConsumerApi[F, K, V]] =
         ConsumerApi.Avro.resource[F, K, V]((configs.toMap + SpecificAvroReader(true)).toSeq: _*)
-
-      def stream[F[_]: Async: ContextShift, K, V](
-          configs: (String, AnyRef)*
-      ): Stream[F, ConsumerApi[F, K, V]] =
-        Stream.resource(resource[F, K, V](configs: _*))
     }
   }
 
@@ -202,11 +181,6 @@ object ConsumerApi {
         configs: (String, AnyRef)*
     ): Resource[F, ConsumerApi[F, K, V]] =
       ConsumerApi.Avro.Generic.resource[F](configs: _*).map(Avro4sConsumerImpl(_))
-
-    def stream[F[_]: Async: ContextShift, K: FromRecord, V: FromRecord](
-        configs: (String, AnyRef)*
-    ): Stream[F, ConsumerApi[F, K, V]] =
-      Stream.resource(resource[F, K, V](configs: _*))
   }
 
   object NonShifting {
@@ -225,17 +199,5 @@ object ConsumerApi {
         configs: (String, AnyRef)*
     ): Resource[F, ConsumerApi[F, K, V]] =
       resource[F, K, V](implicitly[Deserializer[K]], implicitly[Deserializer[V]], configs: _*)
-
-    def stream[F[_]: Sync, K, V](
-        keyDeserializer: Deserializer[K],
-        valueDeserializer: Deserializer[V],
-        configs: (String, AnyRef)*
-    ): Stream[F, ConsumerApi[F, K, V]] =
-      Stream.resource(resource[F, K, V](keyDeserializer, valueDeserializer, configs: _*))
-
-    def stream[F[_]: Sync, K: Deserializer, V: Deserializer](
-        configs: (String, AnyRef)*
-    ): Stream[F, ConsumerApi[F, K, V]] =
-      stream[F, K, V](implicitly[Deserializer[K]], implicitly[Deserializer[V]], configs: _*)
   }
 }

--- a/core/src/main/scala/com/banno/kafka/producer/ProducerApi.scala
+++ b/core/src/main/scala/com/banno/kafka/producer/ProducerApi.scala
@@ -18,7 +18,6 @@ package com.banno.kafka.producer
 
 import cats.implicits._
 import cats.effect.{Async, Resource, Sync}
-import fs2.Stream
 import java.util.concurrent.{Future => JFuture}
 import scala.collection.JavaConverters._
 import scala.concurrent.duration._
@@ -90,18 +89,6 @@ object ProducerApi {
   ): Resource[F, ProducerApi[F, K, V]] =
     resource[F, K, V](implicitly[Serializer[K]], implicitly[Serializer[V]], configs: _*)
 
-  def stream[F[_]: Async, K, V](
-      keySerializer: Serializer[K],
-      valueSerializer: Serializer[V],
-      configs: (String, AnyRef)*
-  ): Stream[F, ProducerApi[F, K, V]] =
-    Stream.resource(resource[F, K, V](keySerializer, valueSerializer, configs: _*))
-
-  def stream[F[_]: Async, K: Serializer, V: Serializer](
-      configs: (String, AnyRef)*
-  ): Stream[F, ProducerApi[F, K, V]] =
-    stream[F, K, V](implicitly[Serializer[K]], implicitly[Serializer[V]], configs: _*)
-
   object Avro {
 
     def resource[F[_]: Async, K, V](
@@ -117,20 +104,12 @@ object ProducerApi {
         ).map(ProducerImpl.create[F, K, V](_))
       )(_.close)
 
-    def stream[F[_]: Async, K, V](configs: (String, AnyRef)*): Stream[F, ProducerApi[F, K, V]] =
-      Stream.resource(resource[F, K, V](configs: _*))
-
     object Generic {
 
       def resource[F[_]: Async](
           configs: (String, AnyRef)*
       ): Resource[F, ProducerApi[F, GenericRecord, GenericRecord]] =
         ProducerApi.Avro.resource[F, GenericRecord, GenericRecord](configs: _*)
-
-      def stream[F[_]: Async](
-          configs: (String, AnyRef)*
-      ): Stream[F, ProducerApi[F, GenericRecord, GenericRecord]] =
-        Stream.resource(resource[F](configs: _*))
     }
 
     object Specific {
@@ -144,10 +123,5 @@ object ProducerApi {
         configs: (String, AnyRef)*
     ): Resource[F, ProducerApi[F, K, V]] =
       ProducerApi.Avro.Generic.resource[F](configs: _*).map(Avro4sProducerImpl(_))
-
-    def stream[F[_]: Async, K: ToRecord, V: ToRecord](
-        configs: (String, AnyRef)*
-    ): Stream[F, ProducerApi[F, K, V]] =
-      Stream.resource(resource[F, K, V](configs: _*))
   }
 }

--- a/core/src/test/scala/com/banno/kafka/ConsumerAndProducerApiSpec.scala
+++ b/core/src/test/scala/com/banno/kafka/ConsumerAndProducerApiSpec.scala
@@ -186,12 +186,16 @@ class ConsumerAndProducerApiSpec
 
     forAll { values: Vector[(String, String)] =>
       val actual = (for {
-        p <- Stream.resource(ProducerApi.resource[IO, String, String](BootstrapServers(bootstrapServer)))
-        c <- Stream.resource(ConsumerApi.resource[IO, String, String](
-          BootstrapServers(bootstrapServer),
-          GroupId(groupId),
-          AutoOffsetReset.earliest
-        ))
+        p <- Stream.resource(
+          ProducerApi.resource[IO, String, String](BootstrapServers(bootstrapServer))
+        )
+        c <- Stream.resource(
+          ConsumerApi.resource[IO, String, String](
+            BootstrapServers(bootstrapServer),
+            GroupId(groupId),
+            AutoOffsetReset.earliest
+          )
+        )
         x <- writeAndRead(p, c, topic, values)
       } yield x).compile.toVector.unsafeRunSync()
       actual should ===(values)
@@ -268,13 +272,16 @@ class ConsumerAndProducerApiSpec
       _ <- ProducerApi
         .resource[IO, String, String](BootstrapServers(bootstrapServer))
         .use(_.sendSyncBatch(expected.map(s => new ProducerRecord(topic, s, s))))
-      consume: Stream[IO, String] = Stream.resource(ConsumerApi
-        .resource[IO, String, String](
-          BootstrapServers(bootstrapServer),
-          GroupId(groupId),
-          AutoOffsetReset.earliest,
-          EnableAutoCommit(false)
-        ))
+      consume: Stream[IO, String] = Stream
+        .resource(
+          ConsumerApi
+            .resource[IO, String, String](
+              BootstrapServers(bootstrapServer),
+              GroupId(groupId),
+              AutoOffsetReset.earliest,
+              EnableAutoCommit(false)
+            )
+        )
         .evalTap(_.subscribe(topic))
         .flatMap(_.readProcessCommit(100 millis)(r => storeOrFail(values, r.value))) //only consumes until a failure)
       _ <- consume.attempt.repeat
@@ -298,16 +305,20 @@ class ConsumerAndProducerApiSpec
 
     forAll { values: Vector[(String, Person)] =>
       val actual = (for {
-        p <- Stream.resource(ProducerApi.Avro.resource[IO, String, Person](
-          BootstrapServers(bootstrapServer),
-          SchemaRegistryUrl(schemaRegistryUrl)
-        ))
-        c <- Stream.resource(ConsumerApi.Avro.Specific.resource[IO, String, Person](
-          BootstrapServers(bootstrapServer),
-          GroupId(groupId),
-          AutoOffsetReset.earliest,
-          SchemaRegistryUrl(schemaRegistryUrl)
-        ))
+        p <- Stream.resource(
+          ProducerApi.Avro.resource[IO, String, Person](
+            BootstrapServers(bootstrapServer),
+            SchemaRegistryUrl(schemaRegistryUrl)
+          )
+        )
+        c <- Stream.resource(
+          ConsumerApi.Avro.Specific.resource[IO, String, Person](
+            BootstrapServers(bootstrapServer),
+            GroupId(groupId),
+            AutoOffsetReset.earliest,
+            SchemaRegistryUrl(schemaRegistryUrl)
+          )
+        )
         v <- writeAndRead(p, c, topic, values)
       } yield v).compile.toVector.unsafeRunSync()
       actual should ===(values)
@@ -325,16 +336,20 @@ class ConsumerAndProducerApiSpec
 
     forAll { values: Vector[(PersonId, Person2)] =>
       val actual = (for {
-        p <- Stream.resource(ProducerApi.Avro4s.resource[IO, PersonId, Person2](
-          BootstrapServers(bootstrapServer),
-          SchemaRegistryUrl(schemaRegistryUrl)
-        ))
-        c <- Stream.resource(ConsumerApi.Avro4s.resource[IO, PersonId, Person2](
-          BootstrapServers(bootstrapServer),
-          GroupId(groupId),
-          AutoOffsetReset.earliest,
-          SchemaRegistryUrl(schemaRegistryUrl)
-        ))
+        p <- Stream.resource(
+          ProducerApi.Avro4s.resource[IO, PersonId, Person2](
+            BootstrapServers(bootstrapServer),
+            SchemaRegistryUrl(schemaRegistryUrl)
+          )
+        )
+        c <- Stream.resource(
+          ConsumerApi.Avro4s.resource[IO, PersonId, Person2](
+            BootstrapServers(bootstrapServer),
+            GroupId(groupId),
+            AutoOffsetReset.earliest,
+            SchemaRegistryUrl(schemaRegistryUrl)
+          )
+        )
         v <- writeAndRead(p, c, topic, values)
       } yield v).compile.toVector.unsafeRunSync()
       actual should ===(values)

--- a/docs/src/main/tut/index.md
+++ b/docs/src/main/tut/index.md
@@ -21,30 +21,34 @@ libraryDependencies ++= Seq(
 Sending records to Kafka is an effect. If we wanted to periodically write random integers to a Kafka topic, we could do:
 
 ```scala
+Stream.resource(
 ProducerApi
-  .stream[F, Int, Int](BootstrapServers(kafkaBootstrapServers))
-  .flatMap(
+  .resource[F, Int, Int](BootstrapServers(kafkaBootstrapServers))
+  .map(
     p =>
-      Stream
-        .awakeDelay[F](1 second)
-        .evalMap(
+      Timer[F]
+        .sleep(1 second)
+        .flatMap(
           _ =>
             Sync[F]
               .delay(Random.nextInt())
               .flatMap(i => p.sendAndForget(new ProducerRecord(topic.name, i, i)))
         )
   )
+)
 ```
 
 Polling Kafka for records is also an effect, and we can obtain a stream of records from a topic. We can print the even random integers from the above topic using:
 
 ```scala
-ConsumerApi
-  .stream[F, Int, Int](
-    BootstrapServers(kafkaBootstrapServers),
-    GroupId("example3"),
-    AutoOffsetReset.earliest,
-    EnableAutoCommit(true)
+Stream.resource(
+   ConsumerApi
+      .resource[F, Int, Int](
+        BootstrapServers(kafkaBootstrapServers),
+        GroupId("example3"),
+        AutoOffsetReset.earliest,
+        EnableAutoCommit(true)
+      )
   )
   .evalTap(_.subscribe(topic.name))
   .flatMap(

--- a/examples/src/main/scala/example3/ExampleApp.scala
+++ b/examples/src/main/scala/example3/ExampleApp.scala
@@ -40,7 +40,8 @@ final class ExampleApp[F[_]: Concurrent: ContextShift: Timer] {
 
       _ <- AdminApi.createTopicsIdempotent[F](kafkaBootstrapServers, topic)
 
-      writeStream = Stream.resource(ProducerApi.resource[F, Int, Int](BootstrapServers(kafkaBootstrapServers))
+      writeStream = Stream.resource(
+        ProducerApi.resource[F, Int, Int](BootstrapServers(kafkaBootstrapServers))
           .map(p =>
             Timer[F].sleep(1 second).flatMap(_ =>
               Sync[F].delay(Random.nextInt()).flatMap(i => p.sendAndForget(new ProducerRecord(topic.name, i, i)))

--- a/examples/src/main/scala/example3/ExampleApp.scala
+++ b/examples/src/main/scala/example3/ExampleApp.scala
@@ -40,27 +40,20 @@ final class ExampleApp[F[_]: Concurrent: ContextShift: Timer] {
 
       _ <- AdminApi.createTopicsIdempotent[F](kafkaBootstrapServers, topic)
 
-      writeStream = ProducerApi
-        .stream[F, Int, Int](BootstrapServers(kafkaBootstrapServers))
-        .flatMap(
-          p =>
-            Stream
-              .awakeDelay[F](1 second)
-              .evalMap(
-                _ =>
-                  Sync[F]
-                    .delay(Random.nextInt())
-                    .flatMap(i => p.sendAndForget(new ProducerRecord(topic.name, i, i)))
-              )
-        )
+      writeStream = Stream.resource(ProducerApi.resource[F, Int, Int](BootstrapServers(kafkaBootstrapServers))
+          .map(p =>
+            Timer[F].sleep(1 second).flatMap(_ =>
+              Sync[F].delay(Random.nextInt()).flatMap(i => p.sendAndForget(new ProducerRecord(topic.name, i, i)))
+            )
+          ))
 
-      readStream = ConsumerApi
-        .stream[F, Int, Int](
+      readStream = Stream.resource(ConsumerApi
+        .resource[F, Int, Int](
           BootstrapServers(kafkaBootstrapServers),
           GroupId("example3"),
           AutoOffsetReset.earliest,
           EnableAutoCommit(true)
-        )
+        ))
         .evalTap(_.subscribe(topic.name))
         .flatMap(
           _.recordStream(1.second)


### PR DESCRIPTION
addresses https://github.com/Banno/kafka4s/issues/47

Please let me know if I missed something :) 