### PR TITLE
Making log on poll a trace, as it logs a bunch on debug

### DIFF
--- a/core/src/main/scala/com/banno/kafka/consumer/ConsumerImpl.scala
+++ b/core/src/main/scala/com/banno/kafka/consumer/ConsumerImpl.scala
@@ -110,7 +110,7 @@ case class ConsumerImpl[F[_], K, V](c: Consumer[K, V])(implicit F: Sync[F])
     F.delay(c.pause(partitions.asJavaCollection))
   def paused: F[Set[TopicPartition]] = F.delay(c.paused().asScala.toSet)
   def poll(timeout: FiniteDuration): F[ConsumerRecords[K, V]] =
-    log.debug(s"${Thread.currentThread.getId} poll($timeout)...") *> F.delay(
+    log.trace(s"${Thread.currentThread.getId} poll($timeout)...") *> F.delay(
       c.poll(java.time.Duration.ofMillis(timeout.toMillis))
     )
   def position(partition: TopicPartition): F[Long] = F.delay(c.position(partition))


### PR DESCRIPTION
This logs a _lot_ if you have it on 1 second 60 times a minute :) which can add up when looking for other logs.

I kept it on trace, because it may be nice to see if you're trying to debug an issue?