### PR TITLE
check exception for null to determine success/failure [series/2.x]

### DIFF
--- a/core/src/main/scala/com/banno/kafka/producer/ProducerImpl.scala
+++ b/core/src/main/scala/com/banno/kafka/producer/ProducerImpl.scala
@@ -56,8 +56,8 @@ case class ProducerImpl[F[_], K, V](p: Producer[K, V])(implicit F: Async[F])
       callback: Either[Exception, RecordMetadata] => Unit
   ): Unit = {
     sendRaw(record, new Callback() {
-      def onCompletion(rm: RecordMetadata, e: Exception): Unit =
-        if (rm == null) callback(Left(e)) else callback(Right(rm))
+      override def onCompletion(rm: RecordMetadata, e: Exception): Unit =
+        if (e == null) callback(Right(rm)) else callback(Left(e))
     })
     () //discard the returned JFuture[RecordMetadata]
   }


### PR DESCRIPTION
Either this callback handling logic has always been incorrect, or the Java client changed behavior at some point. Regardless, the `RecordMetadata` is never `null`; the exception is `null` on success case only, so that's the correct thing to check.

The [example in `send` docs](https://kafka.apache.org/24/javadoc/org/apache/kafka/clients/producer/KafkaProducer.html#send-org.apache.kafka.clients.producer.ProducerRecord-org.apache.kafka.clients.producer.Callback-) follows this approach, as do the docs for [`Callback.onCompletion`](https://kafka.apache.org/24/javadoc/org/apache/kafka/clients/producer/Callback.html#onCompletion-org.apache.kafka.clients.producer.RecordMetadata-java.lang.Exception-).