### PR TITLE
Update Threading Semantics

### DIFF
--- a/core/src/main/scala/com/banno/kafka/consumer/ConsumerImpl.scala
+++ b/core/src/main/scala/com/banno/kafka/consumer/ConsumerImpl.scala
@@ -17,7 +17,8 @@
 package com.banno.kafka.consumer
 
 import cats.implicits._
-import cats.effect.Sync
+import cats.effect._
+import cats.effect.concurrent._
 import java.util.regex.Pattern
 
 import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
@@ -27,136 +28,229 @@ import scala.concurrent.duration._
 import org.apache.kafka.common._
 import org.apache.kafka.clients.consumer._
 
-case class ConsumerImpl[F[_], K, V](c: Consumer[K, V])(implicit F: Sync[F])
-    extends ConsumerApi[F, K, V] {
-  import ConsumerImpl.valueIsNotNull
 
-  private[this] val log = Slf4jLogger.getLoggerFromClass(this.getClass)
-  def assign(partitions: Iterable[TopicPartition]): F[Unit] =
-    F.delay(c.assign(partitions.asJavaCollection)) *> log.debug(s"Assigned $partitions")
-  def assignment: F[Set[TopicPartition]] = F.delay(c.assignment().asScala.toSet)
-  def beginningOffsets(partitions: Iterable[TopicPartition]): F[Map[TopicPartition, Long]] =
-    F.delay(c.beginningOffsets(partitions.asJavaCollection).asScala.toMap.mapValues(Long.unbox))
-  def beginningOffsets(
+object ConsumerImpl {
+  private[this] final class ConsumerImpl[F[_], K, V](c: Consumer[K, V])(implicit F: Sync[F])
+      extends ConsumerApi[F, K, V] {
+
+    private[this] val log = Slf4jLogger.getLoggerFromClass(this.getClass)
+    def assign(partitions: Iterable[TopicPartition]): F[Unit] =
+      F.delay(c.assign(partitions.asJavaCollection)) *> log.debug(s"Assigned $partitions")
+    def assignment: F[Set[TopicPartition]] = F.delay(c.assignment().asScala.toSet)
+    def beginningOffsets(partitions: Iterable[TopicPartition]): F[Map[TopicPartition, Long]] =
+      F.delay(c.beginningOffsets(partitions.asJavaCollection).asScala.toMap.mapValues(Long.unbox))
+    def beginningOffsets(
       partitions: Iterable[TopicPartition],
       timeout: FiniteDuration
-  ): F[Map[TopicPartition, Long]] =
-    F.delay(
-      c.beginningOffsets(
+    ): F[Map[TopicPartition, Long]] =
+      F.delay(
+        c.beginningOffsets(
           partitions.asJavaCollection,
           java.time.Duration.ofMillis(timeout.toMillis)
         )
-        .asScala
-        .toMap
-        .mapValues(Long.unbox)
-    )
-  def close: F[Unit] =
-    log.debug(s"${Thread.currentThread.getId} consumer.close()...") *> F.delay(c.close()) *> log
-      .debug(s"${Thread.currentThread.getId} consumer.close()")
-  def close(timeout: FiniteDuration): F[Unit] =
-    log.debug(s"${Thread.currentThread.getId} consumer.close($timeout)...") *> F.delay(
-      c.close(java.time.Duration.ofMillis(timeout.toMillis))
-    ) *> log.debug(s"${Thread.currentThread.getId} consumer.close($timeout)")
-  def commitAsync: F[Unit] = F.delay(c.commitAsync())
-  def commitAsync(
+          .asScala
+          .toMap
+          .mapValues(Long.unbox)
+      )
+    def close: F[Unit] =
+      log.debug(s"${Thread.currentThread.getId} consumer.close()...") *> F.delay(c.close()) *> log
+        .debug(s"${Thread.currentThread.getId} consumer.close()")
+    def close(timeout: FiniteDuration): F[Unit] =
+      log.debug(s"${Thread.currentThread.getId} consumer.close($timeout)...") *> F.delay(
+        c.close(java.time.Duration.ofMillis(timeout.toMillis))
+      ) *> log.debug(s"${Thread.currentThread.getId} consumer.close($timeout)")
+    def commitAsync: F[Unit] = F.delay(c.commitAsync())
+    def commitAsync(
       offsets: Map[TopicPartition, OffsetAndMetadata],
       callback: OffsetCommitCallback
-  ): F[Unit] = F.delay(c.commitAsync(offsets.asJava, callback))
-  def commitAsync(callback: OffsetCommitCallback): F[Unit] = F.delay(c.commitAsync(callback))
-  def commitSync: F[Unit] = F.delay(c.commitSync())
-  def commitSync(offsets: Map[TopicPartition, OffsetAndMetadata]): F[Unit] =
-    F.delay(c.commitSync(offsets.asJava))
-  def committed(
+    ): F[Unit] = F.delay(c.commitAsync(offsets.asJava, callback))
+    def commitAsync(callback: OffsetCommitCallback): F[Unit] = F.delay(c.commitAsync(callback))
+    def commitSync: F[Unit] = F.delay(c.commitSync())
+    def commitSync(offsets: Map[TopicPartition, OffsetAndMetadata]): F[Unit] =
+      F.delay(c.commitSync(offsets.asJava))
+    def committed(
       partitions: Set[TopicPartition]
-  ): F[Map[TopicPartition, OffsetAndMetadata]] =
-    F.delay(
-      c.committed(partitions.asJava)
-        .asScala
-        .filter(valueIsNotNull)
-        .toMap
-    )
-  def endOffsets(partitions: Iterable[TopicPartition]): F[Map[TopicPartition, Long]] =
-    F.delay(c.endOffsets(partitions.asJavaCollection).asScala.toMap.mapValues(Long.unbox))
-  def endOffsets(
+    ): F[Map[TopicPartition, OffsetAndMetadata]] =
+      F.delay(
+        c.committed(partitions.asJava)
+          .asScala
+          .filter(valueIsNotNull)
+          .toMap
+      )
+    def endOffsets(partitions: Iterable[TopicPartition]): F[Map[TopicPartition, Long]] =
+      F.delay(c.endOffsets(partitions.asJavaCollection).asScala.toMap.mapValues(Long.unbox))
+    def endOffsets(
       partitions: Iterable[TopicPartition],
       timeout: FiniteDuration
-  ): F[Map[TopicPartition, Long]] =
-    F.delay(
-      c.endOffsets(partitions.asJavaCollection, java.time.Duration.ofMillis(timeout.toMillis))
-        .asScala
-        .toMap
-        .mapValues(Long.unbox)
-    )
-  def listTopics: F[Map[String, Seq[PartitionInfo]]] =
-    F.delay(c.listTopics().asScala.toMap.mapValues(_.asScala))
-  def listTopics(timeout: FiniteDuration): F[Map[String, Seq[PartitionInfo]]] =
-    F.delay(
-      c.listTopics(java.time.Duration.ofMillis(timeout.toMillis))
-        .asScala
-        .toMap
-        .mapValues(_.asScala)
-    )
-  def metrics: F[Map[MetricName, Metric]] = F.delay(c.metrics().asScala.toMap)
-  def offsetsForTimes(
+    ): F[Map[TopicPartition, Long]] =
+      F.delay(
+        c.endOffsets(partitions.asJavaCollection, java.time.Duration.ofMillis(timeout.toMillis))
+          .asScala
+          .toMap
+          .mapValues(Long.unbox)
+      )
+    def listTopics: F[Map[String, Seq[PartitionInfo]]] =
+      F.delay(c.listTopics().asScala.toMap.mapValues(_.asScala))
+    def listTopics(timeout: FiniteDuration): F[Map[String, Seq[PartitionInfo]]] =
+      F.delay(
+        c.listTopics(java.time.Duration.ofMillis(timeout.toMillis))
+          .asScala
+          .toMap
+          .mapValues(_.asScala)
+      )
+    def metrics: F[Map[MetricName, Metric]] = F.delay(c.metrics().asScala.toMap)
+    def offsetsForTimes(
       timestampsToSearch: Map[TopicPartition, Long]
-  ): F[Map[TopicPartition, OffsetAndTimestamp]] =
-    F.delay(
-      c.offsetsForTimes(timestampsToSearch.mapValues(Long.box).asJava)
-        .asScala
-        .filter(valueIsNotNull)
-        .toMap
-    )
-  def offsetsForTimes(
+    ): F[Map[TopicPartition, OffsetAndTimestamp]] =
+      F.delay(
+        c.offsetsForTimes(timestampsToSearch.mapValues(Long.box).asJava)
+          .asScala
+          .filter(valueIsNotNull)
+          .toMap
+      )
+    def offsetsForTimes(
       timestampsToSearch: Map[TopicPartition, Long],
       timeout: FiniteDuration
-  ): F[Map[TopicPartition, OffsetAndTimestamp]] =
-    F.delay(
-      c.offsetsForTimes(
+    ): F[Map[TopicPartition, OffsetAndTimestamp]] =
+      F.delay(
+        c.offsetsForTimes(
           timestampsToSearch.mapValues(Long.box).asJava,
           java.time.Duration.ofMillis(timeout.toMillis)
         )
-        .asScala
-        .filter(valueIsNotNull)
-        .toMap
-    )
-  def partitionsFor(topic: String): F[Seq[PartitionInfo]] = F.delay(c.partitionsFor(topic).asScala)
-  def partitionsFor(topic: String, timeout: FiniteDuration): F[Seq[PartitionInfo]] =
-    F.delay(c.partitionsFor(topic, java.time.Duration.ofMillis(timeout.toMillis)).asScala)
-  def pause(partitions: Iterable[TopicPartition]): F[Unit] =
-    F.delay(c.pause(partitions.asJavaCollection))
-  def paused: F[Set[TopicPartition]] = F.delay(c.paused().asScala.toSet)
-  def poll(timeout: FiniteDuration): F[ConsumerRecords[K, V]] =
-    log.trace(s"${Thread.currentThread.getId} poll($timeout)...") *> F.delay(
-      c.poll(java.time.Duration.ofMillis(timeout.toMillis))
-    )
-  def position(partition: TopicPartition): F[Long] = F.delay(c.position(partition))
-  def resume(partitions: Iterable[TopicPartition]): F[Unit] =
-    F.delay(c.resume(partitions.asJavaCollection))
-  def seek(partition: TopicPartition, offset: Long): F[Unit] =
-    F.delay(c.seek(partition, offset)) *> log.debug(s"Seeked $partition to $offset")
-  def seekToBeginning(partitions: Iterable[TopicPartition]): F[Unit] =
-    F.delay(c.seekToBeginning(partitions.asJavaCollection)) *> log.debug(
-      s"Seeked to beginning: $partitions"
-    )
-  def seekToEnd(partitions: Iterable[TopicPartition]): F[Unit] =
-    F.delay(c.seekToEnd(partitions.asJavaCollection)) *> log.debug(s"Seeked to end: $partitions")
-  def subscribe(topics: Iterable[String]): F[Unit] = F.delay(c.subscribe(topics.asJavaCollection))
-  def subscribe(topics: Iterable[String], callback: ConsumerRebalanceListener): F[Unit] =
-    F.delay(c.subscribe(topics.asJavaCollection, callback))
-  def subscribe(pattern: Pattern): F[Unit] = F.delay(c.subscribe(pattern))
-  def subscribe(pattern: Pattern, callback: ConsumerRebalanceListener): F[Unit] =
-    F.delay(c.subscribe(pattern, callback))
-  def subscription: F[Set[String]] = F.delay(c.subscription().asScala.toSet)
-  def unsubscribe: F[Unit] = F.delay(c.unsubscribe())
-  def wakeup: F[Unit] = F.delay(c.wakeup())
-}
+          .asScala
+          .filter(valueIsNotNull)
+          .toMap
+      )
+    def partitionsFor(topic: String): F[Seq[PartitionInfo]] = F.delay(c.partitionsFor(topic).asScala)
+    def partitionsFor(topic: String, timeout: FiniteDuration): F[Seq[PartitionInfo]] =
+      F.delay(c.partitionsFor(topic, java.time.Duration.ofMillis(timeout.toMillis)).asScala)
+    def pause(partitions: Iterable[TopicPartition]): F[Unit] =
+      F.delay(c.pause(partitions.asJavaCollection))
+    def paused: F[Set[TopicPartition]] = F.delay(c.paused().asScala.toSet)
+    def poll(timeout: FiniteDuration): F[ConsumerRecords[K, V]] =
+      log.trace(s"${Thread.currentThread.getId} poll($timeout)...") *> F.delay(
+        c.poll(java.time.Duration.ofMillis(timeout.toMillis))
+      )
+    def position(partition: TopicPartition): F[Long] = F.delay(c.position(partition))
+    def resume(partitions: Iterable[TopicPartition]): F[Unit] =
+      F.delay(c.resume(partitions.asJavaCollection))
+    def seek(partition: TopicPartition, offset: Long): F[Unit] =
+      F.delay(c.seek(partition, offset)) *> log.debug(s"Seeked $partition to $offset")
+    def seekToBeginning(partitions: Iterable[TopicPartition]): F[Unit] =
+      F.delay(c.seekToBeginning(partitions.asJavaCollection)) *> log.debug(
+        s"Seeked to beginning: $partitions"
+      )
+    def seekToEnd(partitions: Iterable[TopicPartition]): F[Unit] =
+      F.delay(c.seekToEnd(partitions.asJavaCollection)) *> log.debug(s"Seeked to end: $partitions")
+    def subscribe(topics: Iterable[String]): F[Unit] = F.delay(c.subscribe(topics.asJavaCollection))
+    def subscribe(topics: Iterable[String], callback: ConsumerRebalanceListener): F[Unit] =
+      F.delay(c.subscribe(topics.asJavaCollection, callback))
+    def subscribe(pattern: Pattern): F[Unit] = F.delay(c.subscribe(pattern))
+    def subscribe(pattern: Pattern, callback: ConsumerRebalanceListener): F[Unit] =
+      F.delay(c.subscribe(pattern, callback))
+    def subscription: F[Set[String]] = F.delay(c.subscription().asScala.toSet)
+    def unsubscribe: F[Unit] = F.delay(c.unsubscribe())
+    def wakeup: F[Unit] = F.delay(c.wakeup())
+  }
 
-object ConsumerImpl {
+  private[this] final class SynchronizedConsumerImpl[F[_], K, V](consumerImpl: ConsumerImpl[F, K, V], semaphore: Semaphore[F]) extends ConsumerApi[F, K, V] {
+
+    override final def assign(partitions: Iterable[TopicPartition]): F[Unit] =
+      this.semaphore.withPermit(this.consumerImpl.assign(partitions))
+    override final def assignment: F[Set[TopicPartition]] =
+      this.semaphore.withPermit(this.consumerImpl.assignment)
+    def beginningOffsets(partitions: Iterable[TopicPartition]): F[Map[TopicPartition, Long]] =
+      this.semaphore.withPermit(this.consumerImpl.beginningOffsets(partitions))
+    def beginningOffsets(
+      partitions: Iterable[TopicPartition],
+      timeout: FiniteDuration
+    ): F[Map[TopicPartition, Long]] =
+      this.semaphore.withPermit(this.consumerImpl.beginningOffsets(partitions, timeout))
+    def close: F[Unit] =
+      this.semaphore.withPermit(this.consumerImpl.close)
+    def close(timeout: FiniteDuration): F[Unit] =
+      this.semaphore.withPermit(this.consumerImpl.close(timeout))
+    def commitAsync: F[Unit] =
+      this.semaphore.withPermit(this.consumerImpl.commitAsync)
+    def commitAsync(
+      offsets: Map[TopicPartition, OffsetAndMetadata],
+      callback: OffsetCommitCallback
+    ): F[Unit] =
+      this.semaphore.withPermit(this.consumerImpl.commitAsync(offsets, callback))
+    def commitAsync(callback: OffsetCommitCallback): F[Unit] =
+      this.semaphore.withPermit(this.consumerImpl.commitAsync(callback))
+    def commitSync: F[Unit] =
+      this.semaphore.withPermit(this.consumerImpl.commitSync)
+    def commitSync(offsets: Map[TopicPartition, OffsetAndMetadata]): F[Unit] =
+      this.semaphore.withPermit(this.consumerImpl.commitSync(offsets))
+    def committed(partition: Set[TopicPartition]): F[Map[TopicPartition, OffsetAndMetadata]] =
+      this.semaphore.withPermit(this.consumerImpl.committed(partition))
+    def endOffsets(partitions: Iterable[TopicPartition]): F[Map[TopicPartition, Long]] =
+      this.semaphore.withPermit(this.consumerImpl.endOffsets(partitions))
+    def endOffsets(
+      partitions: Iterable[TopicPartition],
+      timeout: FiniteDuration
+    ): F[Map[TopicPartition, Long]] =
+      this.semaphore.withPermit(this.consumerImpl.endOffsets(partitions, timeout))
+    def listTopics: F[Map[String, Seq[PartitionInfo]]] =
+      this.semaphore.withPermit(this.consumerImpl.listTopics)
+    def listTopics(timeout: FiniteDuration): F[Map[String, Seq[PartitionInfo]]] =
+      this.semaphore.withPermit(this.consumerImpl.listTopics(timeout))
+    def metrics: F[Map[MetricName, Metric]] =
+      this.semaphore.withPermit(this.consumerImpl.metrics)
+    def offsetsForTimes(
+      timestampsToSearch: Map[TopicPartition, Long]
+    ): F[Map[TopicPartition, OffsetAndTimestamp]] =
+      this.semaphore.withPermit(this.consumerImpl.offsetsForTimes(timestampsToSearch))
+    def offsetsForTimes(
+      timestampsToSearch: Map[TopicPartition, Long],
+      timeout: FiniteDuration
+    ): F[Map[TopicPartition, OffsetAndTimestamp]] =
+      this.semaphore.withPermit(this.consumerImpl.offsetsForTimes(timestampsToSearch, timeout))
+    def partitionsFor(topic: String): F[Seq[PartitionInfo]] =
+      this.semaphore.withPermit(this.consumerImpl.partitionsFor(topic))
+    def partitionsFor(topic: String, timeout: FiniteDuration): F[Seq[PartitionInfo]] =
+      this.semaphore.withPermit(this.consumerImpl.partitionsFor(topic, timeout))
+    def pause(partitions: Iterable[TopicPartition]): F[Unit] =
+      this.semaphore.withPermit(this.consumerImpl.pause(partitions))
+    def paused: F[Set[TopicPartition]] =
+      this.semaphore.withPermit(this.consumerImpl.paused)
+    def poll(timeout: FiniteDuration): F[ConsumerRecords[K, V]] =
+      this.semaphore.withPermit(this.consumerImpl.poll(timeout))
+    def position(partition: TopicPartition): F[Long] =
+      this.semaphore.withPermit(this.consumerImpl.position(partition))
+    def resume(partitions: Iterable[TopicPartition]): F[Unit] =
+      this.semaphore.withPermit(this.consumerImpl.resume(partitions))
+    def seek(partition: TopicPartition, offset: Long): F[Unit] =
+      this.semaphore.withPermit(this.consumerImpl.seek(partition, offset))
+    def seekToBeginning(partitions: Iterable[TopicPartition]): F[Unit] =
+      this.semaphore.withPermit(this.consumerImpl.seekToBeginning(partitions))
+    def seekToEnd(partitions: Iterable[TopicPartition]): F[Unit] =
+      this.semaphore.withPermit(this.consumerImpl.seekToEnd(partitions))
+    def subscribe(topics: Iterable[String]): F[Unit] =
+      this.semaphore.withPermit(this.consumerImpl.subscribe(topics))
+    def subscribe(topics: Iterable[String], callback: ConsumerRebalanceListener): F[Unit] =
+      this.semaphore.withPermit(this.consumerImpl.subscribe(topics, callback))
+    def subscribe(pattern: Pattern): F[Unit] =
+      this.semaphore.withPermit(this.consumerImpl.subscribe(pattern))
+    def subscribe(pattern: Pattern, callback: ConsumerRebalanceListener): F[Unit] =
+      this.semaphore.withPermit(this.consumerImpl.subscribe(pattern, callback))
+    def subscription: F[Set[String]] =
+      this.semaphore.withPermit(this.consumerImpl.subscription)
+    def unsubscribe: F[Unit] =
+      this.semaphore.withPermit(this.consumerImpl.unsubscribe)
+    def wakeup: F[Unit] =
+      // Thread safe
+      this.consumerImpl.wakeup
+  }
+
   //returns the type expected when creating a Resource
-  def create[F[_]: Sync, K, V](
+  def create[F[_]: Concurrent, K, V](
       c: Consumer[K, V]
-  ): ConsumerApi[F, K, V] =
-    ConsumerImpl(c)
+  ): F[ConsumerApi[F, K, V]] =
+    Semaphore(1L).map(s =>
+      new SynchronizedConsumerImpl(new ConsumerImpl(c), s)
+    )
 
   def valueIsNotNull[A](keyValPair: (TopicPartition, A)): Boolean =
     keyValPair._2 != null

--- a/core/src/main/scala/com/banno/kafka/consumer/ShiftingConsumerImpl.scala
+++ b/core/src/main/scala/com/banno/kafka/consumer/ShiftingConsumerImpl.scala
@@ -16,100 +16,97 @@
 
 package com.banno.kafka.consumer
 
-import cats.effect.{Async, ContextShift}
+import cats.effect._
 import java.util.regex.Pattern
 
 import scala.concurrent.duration._
 import org.apache.kafka.common._
 import org.apache.kafka.clients.consumer._
 
-import scala.concurrent.ExecutionContext
-
 case class ShiftingConsumerImpl[F[_]: Async, K, V](
     c: ConsumerApi[F, K, V],
-    blockingContext: ExecutionContext
+    blockingContext: Blocker
 )(implicit CS: ContextShift[F])
     extends ConsumerApi[F, K, V] {
   def assign(partitions: Iterable[TopicPartition]): F[Unit] =
-    CS.evalOn(blockingContext)(c.assign(partitions))
-  def assignment: F[Set[TopicPartition]] = CS.evalOn(blockingContext)(c.assignment)
+    this.blockingContext.blockOn(c.assign(partitions))
+  def assignment: F[Set[TopicPartition]] = this.blockingContext.blockOn(c.assignment)
   def beginningOffsets(partitions: Iterable[TopicPartition]): F[Map[TopicPartition, Long]] =
-    CS.evalOn(blockingContext)(c.beginningOffsets(partitions))
+    this.blockingContext.blockOn(c.beginningOffsets(partitions))
   def beginningOffsets(
       partitions: Iterable[TopicPartition],
       timeout: FiniteDuration
   ): F[Map[TopicPartition, Long]] =
-    CS.evalOn(blockingContext)(c.beginningOffsets(partitions, timeout))
-  def close: F[Unit] = CS.evalOn(blockingContext)(c.close)
-  def close(timeout: FiniteDuration): F[Unit] = CS.evalOn(blockingContext)(c.close(timeout))
-  def commitAsync: F[Unit] = CS.evalOn(blockingContext)(c.commitAsync)
+    this.blockingContext.blockOn(c.beginningOffsets(partitions, timeout))
+  def close: F[Unit] = this.blockingContext.blockOn(c.close)
+  def close(timeout: FiniteDuration): F[Unit] = this.blockingContext.blockOn(c.close(timeout))
+  def commitAsync: F[Unit] = this.blockingContext.blockOn(c.commitAsync)
   def commitAsync(
       offsets: Map[TopicPartition, OffsetAndMetadata],
       callback: OffsetCommitCallback
   ): F[Unit] =
-    CS.evalOn(blockingContext)(c.commitAsync(offsets, callback))
+    this.blockingContext.blockOn(c.commitAsync(offsets, callback))
   def commitAsync(callback: OffsetCommitCallback): F[Unit] =
-    CS.evalOn(blockingContext)(c.commitAsync(callback))
-  def commitSync: F[Unit] = CS.evalOn(blockingContext)(c.commitSync)
+    this.blockingContext.blockOn(c.commitAsync(callback))
+  def commitSync: F[Unit] = this.blockingContext.blockOn(c.commitSync)
   def commitSync(offsets: Map[TopicPartition, OffsetAndMetadata]): F[Unit] =
-    CS.evalOn(blockingContext)(c.commitSync(offsets))
+    this.blockingContext.blockOn(c.commitSync(offsets))
   def committed(partition: Set[TopicPartition]): F[Map[TopicPartition, OffsetAndMetadata]] =
-    CS.evalOn(blockingContext)(c.committed(partition))
+    this.blockingContext.blockOn(c.committed(partition))
   def endOffsets(partitions: Iterable[TopicPartition]): F[Map[TopicPartition, Long]] =
-    CS.evalOn(blockingContext)(c.endOffsets(partitions))
+    this.blockingContext.blockOn(c.endOffsets(partitions))
   def endOffsets(
       partitions: Iterable[TopicPartition],
       timeout: FiniteDuration
   ): F[Map[TopicPartition, Long]] =
-    CS.evalOn(blockingContext)(c.endOffsets(partitions, timeout))
-  def listTopics: F[Map[String, Seq[PartitionInfo]]] = CS.evalOn(blockingContext)(c.listTopics)
+    this.blockingContext.blockOn(c.endOffsets(partitions, timeout))
+  def listTopics: F[Map[String, Seq[PartitionInfo]]] = this.blockingContext.blockOn(c.listTopics)
   def listTopics(timeout: FiniteDuration): F[Map[String, Seq[PartitionInfo]]] =
-    CS.evalOn(blockingContext)(c.listTopics(timeout))
-  def metrics: F[Map[MetricName, Metric]] = CS.evalOn(blockingContext)(c.metrics)
+    this.blockingContext.blockOn(c.listTopics(timeout))
+  def metrics: F[Map[MetricName, Metric]] = this.blockingContext.blockOn(c.metrics)
   def offsetsForTimes(
       timestampsToSearch: Map[TopicPartition, Long]
   ): F[Map[TopicPartition, OffsetAndTimestamp]] =
-    CS.evalOn(blockingContext)(c.offsetsForTimes(timestampsToSearch))
+    this.blockingContext.blockOn(c.offsetsForTimes(timestampsToSearch))
   def offsetsForTimes(
       timestampsToSearch: Map[TopicPartition, Long],
       timeout: FiniteDuration
   ): F[Map[TopicPartition, OffsetAndTimestamp]] =
-    CS.evalOn(blockingContext)(c.offsetsForTimes(timestampsToSearch, timeout))
+    this.blockingContext.blockOn(c.offsetsForTimes(timestampsToSearch, timeout))
   def partitionsFor(topic: String): F[Seq[PartitionInfo]] =
-    CS.evalOn(blockingContext)(c.partitionsFor(topic))
+    this.blockingContext.blockOn(c.partitionsFor(topic))
   def partitionsFor(topic: String, timeout: FiniteDuration): F[Seq[PartitionInfo]] =
-    CS.evalOn(blockingContext)(c.partitionsFor(topic, timeout))
+    this.blockingContext.blockOn(c.partitionsFor(topic, timeout))
   def pause(partitions: Iterable[TopicPartition]): F[Unit] =
-    CS.evalOn(blockingContext)(c.pause(partitions))
-  def paused: F[Set[TopicPartition]] = CS.evalOn(blockingContext)(c.paused)
+    this.blockingContext.blockOn(c.pause(partitions))
+  def paused: F[Set[TopicPartition]] = this.blockingContext.blockOn(c.paused)
   def poll(timeout: FiniteDuration): F[ConsumerRecords[K, V]] =
-    CS.evalOn(blockingContext)(c.poll(timeout))
+    this.blockingContext.blockOn(c.poll(timeout))
   def position(partition: TopicPartition): F[Long] =
-    CS.evalOn(blockingContext)(c.position(partition))
+    this.blockingContext.blockOn(c.position(partition))
   def resume(partitions: Iterable[TopicPartition]): F[Unit] =
-    CS.evalOn(blockingContext)(c.resume(partitions))
+    this.blockingContext.blockOn(c.resume(partitions))
   def seek(partition: TopicPartition, offset: Long): F[Unit] =
-    CS.evalOn(blockingContext)(c.seek(partition, offset))
+    this.blockingContext.blockOn(c.seek(partition, offset))
   def seekToBeginning(partitions: Iterable[TopicPartition]): F[Unit] =
-    CS.evalOn(blockingContext)(c.seekToBeginning(partitions))
+    this.blockingContext.blockOn(c.seekToBeginning(partitions))
   def seekToEnd(partitions: Iterable[TopicPartition]): F[Unit] =
-    CS.evalOn(blockingContext)(c.seekToEnd(partitions))
-  def subscribe(topics: Iterable[String]): F[Unit] = CS.evalOn(blockingContext)(c.subscribe(topics))
+    this.blockingContext.blockOn(c.seekToEnd(partitions))
+  def subscribe(topics: Iterable[String]): F[Unit] = this.blockingContext.blockOn(c.subscribe(topics))
   def subscribe(topics: Iterable[String], callback: ConsumerRebalanceListener): F[Unit] =
-    CS.evalOn(blockingContext)(c.subscribe(topics, callback))
-  def subscribe(pattern: Pattern): F[Unit] = CS.evalOn(blockingContext)(c.subscribe(pattern))
+    this.blockingContext.blockOn(c.subscribe(topics, callback))
+  def subscribe(pattern: Pattern): F[Unit] = this.blockingContext.blockOn(c.subscribe(pattern))
   def subscribe(pattern: Pattern, callback: ConsumerRebalanceListener): F[Unit] =
-    CS.evalOn(blockingContext)(c.subscribe(pattern, callback))
-  def subscription: F[Set[String]] = CS.evalOn(blockingContext)(c.subscription)
-  def unsubscribe: F[Unit] = CS.evalOn(blockingContext)(c.unsubscribe)
+    this.blockingContext.blockOn(c.subscribe(pattern, callback))
+  def subscription: F[Set[String]] = this.blockingContext.blockOn(c.subscription)
+  def unsubscribe: F[Unit] = this.blockingContext.blockOn(c.unsubscribe)
   def wakeup: F[Unit] = c.wakeup //TODO wakeup is the one method that is thread-safe, right?
 }
 
 object ShiftingConsumerImpl {
-  //returns the type expected when creating a Resource
   def create[F[_]: Async: ContextShift, K, V](
       c: ConsumerApi[F, K, V],
-      e: ExecutionContext
+      b: Blocker
   ): ConsumerApi[F, K, V] =
-    ShiftingConsumerImpl(c, e)
+    ShiftingConsumerImpl(c, b)
 }

--- a/examples/src/main/scala/example1/ExampleApp.scala
+++ b/examples/src/main/scala/example1/ExampleApp.scala
@@ -29,7 +29,7 @@ import org.apache.kafka.clients.producer.ProducerRecord
 import scala.concurrent.duration._
 import org.apache.kafka.common.TopicPartition
 
-final class ExampleApp[F[_]: Async: ContextShift] {
+final class ExampleApp[F[_]: Concurrent: ContextShift] {
   import ExampleApp._
 
   // Change these for your environment as needed
@@ -112,5 +112,5 @@ object ExampleApp {
   implicit def customerIdRecordFormat = RecordFormat[CustomerId]
   implicit def customerRecordFormat = RecordFormat[Customer]
 
-  def apply[F[_]: Async: ContextShift] = new ExampleApp[F]
+  def apply[F[_]: Concurrent: ContextShift] = new ExampleApp[F]
 }

--- a/examples/src/main/scala/example2/ExampleApp.scala
+++ b/examples/src/main/scala/example2/ExampleApp.scala
@@ -29,7 +29,7 @@ import org.apache.kafka.clients.producer.ProducerRecord
 import scala.concurrent.duration._
 import org.apache.kafka.common.TopicPartition
 
-final class ExampleApp[F[_]: Async: ContextShift] {
+final class ExampleApp[F[_]: Concurrent: ContextShift] {
   import ExampleApp._
 
   // Change these for your environment as needed
@@ -113,7 +113,7 @@ object ExampleApp {
   implicit def customerRecordFormat = RecordFormat[Customer]
   implicit def priorityRecordFormat = RecordFormat[Priority]
 
-  def apply[F[_]: Async: ContextShift] = new ExampleApp[F]
+  def apply[F[_]: Concurrent: ContextShift] = new ExampleApp[F]
 }
 
 case class CustomerId(id: String)


### PR DESCRIPTION
This commit makes a few changes related to the threading setup in `ConsumerApi` and `ProducerApi`.

It addresses unclean shutdown of the `java.util.concurrent.ExecutorService` as well as fixing a potential deadlock scenario.

Prior to this commit an `ExecutorService` with a single thread was created in `ConsumerApi.BlockingContext`. For blocking IO operations an unbounded thread pool is recommended (https://typelevel.org/cats-effect/concurrency/basics.html#choosing-thread-pool). Preventing unbounded resource usage is the responsibility for calling code running on a bounded thread pool.

This commit also updates the `ThreadFactory` so that if multiple pools happen to be created, they will be given globally unique names.

Two new methods are added to the companion object of `ConsumerApi` to allow for the caller to provider their own `Blocker` if so desired.

Also, the shutdown of the thread pool prior to this commit only called `(es: ExecutorService).shutdown()`. This is not sufficient to shutdown an `ExecutorService`. The full process is actually quite involved (https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/concurrent/ExecutorService.html). Thankfully `cats-effect` already provides this logic for us out of the box with `Blocker.fromExecutorService`.

Both the single threaded nature of the blocker _and_ the shutdown semantics were issues. The impetus for this commit is that we were experiencing a deadlock around shutdown/restart of a `fs2.Stream` with Kafka4s related code. I strongly believe that one or both of these is the source of that issue, however even if it is not, these items should still be addressed.

This is a binary incompatible change.