### PR TITLE
Build for jdk11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ scala:
 
 jdk:
   - openjdk8
+  - openjdk11
 
 before_install:
   - git fetch --tags

--- a/build.sbt
+++ b/build.sbt
@@ -156,6 +156,13 @@ lazy val commonSettings = Seq(
       .classifier("tests")
       .exclude("org.slf4j", "slf4j-log4j12")
       .exclude("log4j", "log4j"),
+    // A fix from @coacoas that allows building for JDK 11.
+    // io.confluent:kafka-schema-registry:5.4.1
+    // depends on io.confluent:rest-utils:5.4.1
+    // which depends on jersey-bean-validation:2.28
+    // which depends on hibernate-validator:6.0.11.Final
+    // which gives rise to https://hibernate.atlassian.net/browse/HV-1644.
+    "org.hibernate.validator" % "hibernate-validator" % "6.0.12.Final",
     "junit" % "junit" % V.junit % "test",
     "ch.qos.logback" % "logback-classic" % V.logback % "test",
     "org.slf4j" % "log4j-over-slf4j" % V.log4j % "test",


### PR DESCRIPTION
Thanks and credit goes to @coacoas for both finding the cause of the jdk11 build issue and suggesting the temporary fix. A summary of the issue:

>It seems that it stems from an issue in Hibernate: https://hibernate.atlassian.net/browse/HV-1644, specifically around hibernate-validator:6.0.11.Final.
This version is being pulled in from jersey-bean-validation:2.28, which is pulled in from io.confluent:rest-utils:5.4.1, which is pulled in from io.confluent:kafka-schema-registry:5.4.1.
I was able to make it build by adding
    "org.hibernate.validator" % "hibernate-validator" % "6.0.12.Final",
to the dependencies, but this certainly isn’t a good solution.

Closes #180 