### PR TITLE
Add back nextOffsets to 2.12 build

### DIFF
--- a/core/src/main/scala-2.12/com/banno/kafka/package.scala
+++ b/core/src/main/scala-2.12/com/banno/kafka/package.scala
@@ -63,6 +63,9 @@ package object kafka {
     def lastOffsets: Map[TopicPartition, Long] =
       crs.partitions.asScala.toSeq.map(tp => (tp -> crs.records(tp).asScala.last.offset)).toMap
 
+    /** lastOffsets + 1, can be used to commit the offsets that the consumer should read next, after these records. */
+    def nextOffsets: Map[TopicPartition, OffsetAndMetadata] =
+      lastOffsets.mapValues(o => new OffsetAndMetadata(o + 1))
   }
 
   implicit class ScalaConsumerRecord[K, V](cr: ConsumerRecord[K, V]) {


### PR DESCRIPTION
I must have somehow accidentally removed this when moving stuff into 2.12- and 2.13-specific dirs. Probably a copy-paste error.