### PR TITLE
Use replication factor of 1 in the description

### DIFF
--- a/docs/src/main/tut/docs/index.md
+++ b/docs/src/main/tut/docs/index.md
@@ -44,7 +44,7 @@ import org.apache.kafka.clients.admin.NewTopic
 Now we can create a topic named `customers.v1` with 1 partition and 3 replicas:
 
 ```tut
-val topic = new NewTopic("customers.v1", 1, 1.toShort)
+val topic = new NewTopic("customers.v1", 1, 3.toShort)
 val kafkaBootstrapServers = "localhost:9092" // Change as needed
 AdminApi.createTopicsIdempotent[IO](kafkaBootstrapServers, topic :: Nil).unsafeRunSync
 ```

--- a/docs/src/main/tut/docs/index.md
+++ b/docs/src/main/tut/docs/index.md
@@ -41,10 +41,10 @@ import com.banno.kafka._, com.banno.kafka.admin._
 import org.apache.kafka.clients.admin.NewTopic
 ```
 
-Now we can create a topic named `customers.v1` with 1 partition and 3 replicas:
+Now we can create a topic named `customers.v1` with 1 partition and 1 replica:
 
 ```tut
-val topic = new NewTopic("customers.v1", 1, 3.toShort)
+val topic = new NewTopic("customers.v1", 1, 1.toShort)
 val kafkaBootstrapServers = "localhost:9092" // Change as needed
 AdminApi.createTopicsIdempotent[IO](kafkaBootstrapServers, topic :: Nil).unsafeRunSync
 ```


### PR DESCRIPTION
Noticed this as I was reading through the docs, the description says a replication factor of 3, but the code was giving it a 1.  As zcox pointed out we can't use 3 as the replication factor as there is only a single broker, which will end up failing.  This changes the description to have a `1` as the replication factor along with keeping the parameter as the 1 it originally was.  

