### PR TITLE
Utils for working with non-deserializing consumers

### DIFF
--- a/core/src/main/scala/com/banno/kafka/consumer/ConsumerApi.scala
+++ b/core/src/main/scala/com/banno/kafka/consumer/ConsumerApi.scala
@@ -135,6 +135,11 @@ object ConsumerApi {
   ): Resource[F, ConsumerApi[F, K, V]] =
     resource[F, K, V](implicitly[Deserializer[K]], implicitly[Deserializer[V]], configs: _*)
 
+  object ByteArray {
+    def resource[F[_]: Async: ContextShift](configs: (String, AnyRef)*): Resource[F, ConsumerApi[F, Array[Byte], Array[Byte]]] = 
+      ConsumerApi.resource[F, Array[Byte], Array[Byte]](configs: _*)
+  }
+
   object Avro {
 
     def resource[F[_]: Async: ContextShift, K, V](

--- a/core/src/main/scala/com/banno/kafka/consumer/ConsumerApi.scala
+++ b/core/src/main/scala/com/banno/kafka/consumer/ConsumerApi.scala
@@ -136,7 +136,9 @@ object ConsumerApi {
     resource[F, K, V](implicitly[Deserializer[K]], implicitly[Deserializer[V]], configs: _*)
 
   object ByteArray {
-    def resource[F[_]: Async: ContextShift](configs: (String, AnyRef)*): Resource[F, ConsumerApi[F, Array[Byte], Array[Byte]]] = 
+    def resource[F[_]: Async: ContextShift](
+        configs: (String, AnyRef)*
+    ): Resource[F, ConsumerApi[F, Array[Byte], Array[Byte]]] =
       ConsumerApi.resource[F, Array[Byte], Array[Byte]](configs: _*)
   }
 

--- a/core/src/main/scala/com/banno/kafka/package.scala
+++ b/core/src/main/scala/com/banno/kafka/package.scala
@@ -144,7 +144,8 @@ package object kafka {
     def valueAs[V](topic: String)(implicit vd: Deserializer[V]): V = vd.deserialize(topic, cr.value)
 
     /** This only works when both key and value are non-null. */
-    def as[K, V](topic: String)(implicit
+    def as[K, V](topic: String)(
+        implicit
         kd: Deserializer[K],
         vd: Deserializer[V]
     ): ConsumerRecord[K, V] =
@@ -155,7 +156,9 @@ package object kafka {
     def recordListAs[K: Deserializer, V: Deserializer](topic: String): List[ConsumerRecord[K, V]] =
       crs.recordList(topic).map(_.as[K, V](topic))
 
-    def recordStreamAs[F[_], K: Deserializer, V: Deserializer](topic: String): Stream[F, ConsumerRecord[K, V]] =
+    def recordStreamAs[F[_], K: Deserializer, V: Deserializer](
+        topic: String
+    ): Stream[F, ConsumerRecord[K, V]] =
       crs.recordStream[F](topic).map(_.as[K, V](topic))
   }
 


### PR DESCRIPTION
Adds a few utils for working `ConsumerApi[F, Array[Byte], Array[Byte]]`, `ConsumerRecord[Array[Byte], Array[Byte]]`, etc.