### PR TITLE
refactor: rename implicit class to free up namespace

### DIFF
--- a/core/src/main/scala/com/banno/kafka/package.scala
+++ b/core/src/main/scala/com/banno/kafka/package.scala
@@ -185,7 +185,9 @@ package object kafka {
       fab.bimap(f, g)
   }
 
-  implicit class Record[F[_, _], A, B](r: F[A, B])(implicit F: Bifunctor[F]) {
+  implicit class BifunctorToOptionExtension[F[_, _], A, B](
+    r: F[A, B]
+  )(implicit F: Bifunctor[F]) {
     def toOption: F[Option[A], Option[B]] = F.bimap(r)(Option.apply, Option.apply)
   }
 


### PR DESCRIPTION
Since this is just an implicit class, give it a longer and more obscure name so that the name `Record` is available for something explicit.