### PR TITLE
fix: remove library dependency on `github4s`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -105,7 +105,6 @@ lazy val site = project
         "gray-lighter" -> "#F4F3F4",
         "white-color" -> "#FFFFFF",
       ),
-      libraryDependencies += "com.47deg" %% "github4s" % V.github4s,
       scalacOptions += "-Wconf:cat=deprecation:i",
       mdocExtraArguments += "--no-link-hygiene",
       micrositePushSiteWith := GitHub4s,


### PR DESCRIPTION
Having this as a library dependency tangles the versions of its dependencies
with the versions of `kafka4s`'s dependencies. The immediate problem is that
this is making the Cats Effect 3 upgrade intractable for no reason, but more
broadly speaking, we don't even care at the end of the day whether `github4s` is
implemented in Scala. We just need it in our build. Our dependencies should be
utterly independent of it.