### PR TITLE
KAYAK-887 clean: drop support for Scala 2.12

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 env:
   CI: true
   CI_SNAPSHOT_RELEASE: +publishSigned
-  SCALA_VERSION: 2.13.4
+  SCALA_VERSION: 2.13.5
 jobs:
   validate:
     name: Scala ${{ matrix.scala }}, Java ${{ matrix.java }}
@@ -14,7 +14,7 @@ jobs:
       matrix:
         # java: [adopt@1.8.0-272, adopt@1.11.0-9, adopt@1.15.0-1]
         java: [adopt@1.11.0-9]
-        scala: [2.12.12, 2.13.4]
+        scala: [2.13.5]
     env:
       SCALA_VERSION: ${{ matrix.scala }}
     steps:
@@ -34,9 +34,6 @@ jobs:
         with:
           path: ~/.sbt
           key: sbt-${{ hashFiles('**/build.sbt') }}
-      - name: Check formatting
-        if: startsWith(matrix.scala, '2.12.') && (matrix.java == 'adopt@1.8.0-272')
-        run: sbt ++$SCALA_VERSION scalafmtCheckAll
       - name: Check copyright headers
         if: matrix.java == 'adopt@1.8.0-272'
         run: sbt ++$SCALA_VERSION headerCheck

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,7 +7,7 @@ on:
       - '*'
 env:
   CI: true
-  SCALA_VERSION: 2.13.4
+  SCALA_VERSION: 2.13.5
 jobs:
   release:
     name: Release

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # kafka4s - Functional programming with Kafka and Scala
 
-![CI](https://github.com/Banno/kafka4s/workflows/CI/badge.svg) 
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.banno/kafka4s_2.13/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.banno/kafka4s_2.13) 
+![CI](https://github.com/Banno/kafka4s/workflows/CI/badge.svg)
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.banno/kafka4s_2.13/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.banno/kafka4s_2.13)
 [![Javadocs](https://www.javadoc.io/badge/com.banno/kafka4s_2.13.svg?color=red&label=scaladoc)](https://www.javadoc.io/doc/com.banno/kafka4s_2.13/latest/com/banno/kafka/index.html)
 [![License](http://img.shields.io/:license-Apache%202-green.svg)](http://www.apache.org/licenses/LICENSE-2.0.txt)
 ![Code of Conduct](https://img.shields.io/badge/Code%20of%20Conduct-Scala-blue.svg)
@@ -12,7 +12,7 @@ kafka4s provides pure, referentially transparent functions for working with Kafk
 
 ## Quick Start
 
-To use kafka4s in an existing SBT project with Scala 2.12 or a later version, add the following dependencies to your
+To use `kafka4s` in an existing SBT project with Scala 2.13 or a later version, add the following dependencies to your
 `build.sbt` depending on your needs:
 
 ```scala
@@ -62,5 +62,4 @@ Stream.resource(
 
 ## Learning more
 
-To learn more about kafka4s, start with our [Getting Started Guide](https://banno.github.io/kafka4s/docs/), play with some [example apps](https://github.com/Banno/kafka4s/tree/master/examples/src/main/scala), and check out the [kafka4s Scaladoc](https://www.javadoc.io/doc/com.banno/kafka4s_2.12) for more info.
-
+To learn more about kafka4s, start with our [Getting Started Guide](https://banno.github.io/kafka4s/docs/), play with some [example apps](https://github.com/Banno/kafka4s/tree/master/examples/src/main/scala), and check out the [kafka4s Scaladoc](https://www.javadoc.io/doc/com.banno/kafka4s_2.13) for more info.

--- a/build.sbt
+++ b/build.sbt
@@ -1,10 +1,8 @@
 Global / onChangedBuildSource := ReloadOnSourceChanges
 
 val V = new {
-  val scala_3_0 = "3.0.0-RC1"
-  val scala_2_13 = "2.13.5"
-  val scala_2_12 = "2.12.13"
-  val scalaVersion :: crossScalaVersions = List(scala_3_0, scala_2_13, scala_2_12)
+  val scalaVersion = "2.13.5"
+  val crossScalaVersions = List()
   val avro4s = "3.1.0"
   val betterMonadicFor = "0.3.1"
   val cats = "2.6.0"
@@ -43,14 +41,9 @@ lazy val core = project
       import com.typesafe.tools.mima.core.ProblemFilters._
       Seq()
     },
-    scalacOptions --= Seq(
-      "-Wunused:imports",
-      "-Ywarn-unused:imports",
-    ),
   )
   .settings(
     libraryDependencies ++= Seq(
-      "org.scala-lang.modules" %% "scala-collection-compat" % "2.4.3",
       "org.apache.curator" % "curator-test" % V.curator % "test",
       ("org.apache.kafka" %% "kafka" % V.kafka % "test").classifier("test"),
       ("org.apache.kafka" % "kafka-clients" % V.kafka % "test").classifier("test"),
@@ -153,6 +146,7 @@ lazy val commonSettings = Seq(
 lazy val contributors = Seq(
   "amohrland" -> "Andrew Mohrland",
   "zcox" -> "Zach Cox",
+  "kazark" -> "Keith Pinson",
 )
 
 inThisBuild(

--- a/core/src/main/scala/com/banno/kafka/admin/AdminApi.scala
+++ b/core/src/main/scala/com/banno/kafka/admin/AdminApi.scala
@@ -16,7 +16,6 @@
 
 package com.banno.kafka.admin
 
-import scala.collection.compat._
 import cats.implicits._
 import cats.effect.{Resource, Sync}
 import fs2.Stream

--- a/core/src/main/scala/com/banno/kafka/admin/AdminImpl.scala
+++ b/core/src/main/scala/com/banno/kafka/admin/AdminImpl.scala
@@ -16,7 +16,6 @@
 
 package com.banno.kafka.admin
 
-import scala.collection.compat._
 import cats.effect.Sync
 import org.apache.kafka.common.TopicPartitionReplica
 import org.apache.kafka.common.config.ConfigResource

--- a/core/src/main/scala/com/banno/kafka/consumer/ConsumerApi.scala
+++ b/core/src/main/scala/com/banno/kafka/consumer/ConsumerApi.scala
@@ -16,7 +16,6 @@
 
 package com.banno.kafka.consumer
 
-import scala.collection.compat._
 import fs2.Stream
 import cats.effect._
 import cats.implicits._

--- a/core/src/main/scala/com/banno/kafka/consumer/ConsumerImpl.scala
+++ b/core/src/main/scala/com/banno/kafka/consumer/ConsumerImpl.scala
@@ -16,7 +16,6 @@
 
 package com.banno.kafka.consumer
 
-import scala.collection.compat._
 import cats.implicits._
 import cats.effect.Sync
 import java.util.regex.Pattern

--- a/core/src/main/scala/com/banno/kafka/consumer/ConsumerOps.scala
+++ b/core/src/main/scala/com/banno/kafka/consumer/ConsumerOps.scala
@@ -16,7 +16,6 @@
 
 package com.banno.kafka.consumer
 
-import scala.collection.compat._
 import cats._
 import cats.implicits._
 import fs2._

--- a/core/src/main/scala/com/banno/kafka/consumer/RecordStreamOps.scala
+++ b/core/src/main/scala/com/banno/kafka/consumer/RecordStreamOps.scala
@@ -17,7 +17,6 @@
 package com.banno.kafka.consumer
 
 import cats._
-import cats.syntax.all._
 import fs2.Stream
 import org.apache.kafka.common.errors.WakeupException
 

--- a/core/src/main/scala/com/banno/kafka/consumer/package.scala
+++ b/core/src/main/scala/com/banno/kafka/consumer/package.scala
@@ -17,7 +17,6 @@
 package com.banno.kafka
 
 import cats._
-import cats.syntax.all._
 import fs2.Stream
 
 package object consumer {

--- a/core/src/main/scala/com/banno/kafka/metrics/IOMetricsReporter.scala
+++ b/core/src/main/scala/com/banno/kafka/metrics/IOMetricsReporter.scala
@@ -16,7 +16,6 @@
 
 package com.banno.kafka.metrics
 
-import scala.collection.compat._
 import org.apache.kafka.common.metrics.{KafkaMetric, MetricsReporter}
 import cats.effect.IO
 import java.util.{Map => JMap, List => JList}

--- a/core/src/main/scala/com/banno/kafka/metrics/MetricsReporterApi.scala
+++ b/core/src/main/scala/com/banno/kafka/metrics/MetricsReporterApi.scala
@@ -16,7 +16,6 @@
 
 package com.banno.kafka.metrics
 
-import scala.collection.compat._
 import org.apache.kafka.common.metrics.KafkaMetric
 
 /** So we can write pure code to report Kafka client metrics. */

--- a/core/src/main/scala/com/banno/kafka/metrics/prometheus/PrometheusMetricsReporterApi.scala
+++ b/core/src/main/scala/com/banno/kafka/metrics/prometheus/PrometheusMetricsReporterApi.scala
@@ -28,7 +28,7 @@ import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
 import io.prometheus.client._
 import org.apache.kafka.common.MetricName
 import org.apache.kafka.common.metrics.KafkaMetric
-import scala.collection.compat._
+
 import scala.concurrent.duration._
 import scala.jdk.CollectionConverters._
 import scala.math.max

--- a/core/src/main/scala/com/banno/kafka/package.scala
+++ b/core/src/main/scala/com/banno/kafka/package.scala
@@ -16,7 +16,6 @@
 
 package com.banno
 
-import scala.collection.compat._
 import org.apache.kafka.common.{PartitionInfo, TopicPartition}
 import org.apache.kafka.common.serialization._
 import org.apache.avro.generic.GenericRecord

--- a/core/src/main/scala/com/banno/kafka/producer/KafkaTransactionError.scala
+++ b/core/src/main/scala/com/banno/kafka/producer/KafkaTransactionError.scala
@@ -18,7 +18,6 @@ package com.banno.kafka.producer
 
 import cats.implicits._
 import cats.ApplicativeError
-import org.apache.kafka.clients.producer._
 import org.apache.kafka.common.errors._
 
 /** Represents the types of failures during Kafka transactional writes. */

--- a/core/src/main/scala/com/banno/kafka/producer/ProducerApi.scala
+++ b/core/src/main/scala/com/banno/kafka/producer/ProducerApi.scala
@@ -16,7 +16,6 @@
 
 package com.banno.kafka.producer
 
-import scala.collection.compat._
 import cats.implicits._
 import cats.effect.{Async, Resource, Sync}
 import java.util.concurrent.{Future => JFuture}

--- a/core/src/main/scala/com/banno/kafka/producer/ProducerImpl.scala
+++ b/core/src/main/scala/com/banno/kafka/producer/ProducerImpl.scala
@@ -16,7 +16,6 @@
 
 package com.banno.kafka.producer
 
-import scala.collection.compat._
 import cats.implicits._
 import cats.effect.Async
 import java.util.concurrent.{Future => JFuture}

--- a/core/src/main/scala/com/banno/kafka/producer/ProducerOps.scala
+++ b/core/src/main/scala/com/banno/kafka/producer/ProducerOps.scala
@@ -20,7 +20,6 @@ import cats.{Applicative, Foldable, MonadError, Traverse}
 import cats.implicits._
 import fs2._
 import org.apache.kafka.common._
-import org.apache.kafka.common.errors._
 import org.apache.kafka.clients.consumer.OffsetAndMetadata
 import org.apache.kafka.clients.producer._
 

--- a/core/src/main/scala/com/banno/kafka/schemaregistry/SchemaRegistryApi.scala
+++ b/core/src/main/scala/com/banno/kafka/schemaregistry/SchemaRegistryApi.scala
@@ -16,7 +16,6 @@
 
 package com.banno.kafka.schemaregistry
 
-import scala.collection.compat._
 import org.apache.avro.Schema
 import io.confluent.kafka.schemaregistry.client.{CachedSchemaRegistryClient, SchemaMetadata}
 import io.confluent.kafka.schemaregistry.client.rest.RestService

--- a/core/src/main/scala/com/banno/kafka/schemaregistry/SchemaRegistryImpl.scala
+++ b/core/src/main/scala/com/banno/kafka/schemaregistry/SchemaRegistryImpl.scala
@@ -16,7 +16,6 @@
 
 package com.banno.kafka.schemaregistry
 
-import scala.collection.compat._
 import org.apache.avro.Schema
 import io.confluent.kafka.schemaregistry.client.{SchemaMetadata, SchemaRegistryClient}
 import cats.effect.Sync

--- a/core/src/main/scala/com/banno/kafka/schemaregistry/SchemaRegistryOps.scala
+++ b/core/src/main/scala/com/banno/kafka/schemaregistry/SchemaRegistryOps.scala
@@ -16,7 +16,6 @@
 
 package com.banno.kafka.schemaregistry
 
-import scala.collection.compat._
 import org.apache.avro.Schema
 import com.sksamuel.avro4s.{DefaultFieldMapper, SchemaFor}
 import cats.FlatMap

--- a/core/src/test/scala/com/banno/kafka/AvrohuggerAvro4sSchemaEvolutionSpec.scala
+++ b/core/src/test/scala/com/banno/kafka/AvrohuggerAvro4sSchemaEvolutionSpec.scala
@@ -1,6 +1,5 @@
 package com.banno.kafka
 
-import scala.collection.compat._
 import org.scalatestplus.scalacheck._
 import io.confluent.kafka.serializers._
 import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient

--- a/core/src/test/scala/com/banno/kafka/ConsumerAndProducerApiSpec.scala
+++ b/core/src/test/scala/com/banno/kafka/ConsumerAndProducerApiSpec.scala
@@ -1,11 +1,8 @@
 package com.banno.kafka
 
-import scala.collection.compat._
 import org.scalacheck._
 import cats.implicits._
 import cats.effect._
-import consumer._
-import producer._
 import org.apache.kafka.clients.producer.ProducerRecord
 
 import scala.concurrent.duration._

--- a/core/src/test/scala/com/banno/kafka/metrics/PrometheusMetricsReporterApiSpec.scala
+++ b/core/src/test/scala/com/banno/kafka/metrics/PrometheusMetricsReporterApiSpec.scala
@@ -1,6 +1,5 @@
 package com.banno.kafka.metrics.prometheus
 
-import scala.collection.compat._
 import cats.implicits._
 import cats.effect.IO
 import com.banno.kafka._

--- a/site/docs/docs/index.md
+++ b/site/docs/docs/index.md
@@ -5,7 +5,7 @@ title: Getting Started
 
 # Getting dependency
 
-To use kafka4s in an existing SBT project with Scala 2.12 or a later version, add the following dependencies to your
+To use kafka4s in an existing SBT project with Scala 2.13 or a later version, add the following dependencies to your
 `build.sbt` depending on your needs:
 
 ```scala

--- a/site/docs/docs/kafka-client-metrics.md
+++ b/site/docs/docs/kafka-client-metrics.md
@@ -5,4 +5,4 @@ title: Kafka Client Metrics
 
 # Kafka Client Metrics
 
-Docs coming soon. Check out the [kafka4s Scaladoc](https://www.javadoc.io/doc/com.banno/kafka4s_2.12) for more info.
+Docs coming soon. Check out the [kafka4s Scaladoc](https://www.javadoc.io/doc/com.banno/kafka4s_2.13) for more info.

--- a/site/docs/docs/kafka-consumers.md
+++ b/site/docs/docs/kafka-consumers.md
@@ -5,4 +5,4 @@ title: Kafka Consumers
 
 # Using Kafka Consumers
 
-Docs coming soon. Check out the [kafka4s Scaladoc](https://www.javadoc.io/doc/com.banno/kafka4s_2.12) for more info.
+Docs coming soon. Check out the [kafka4s Scaladoc](https://www.javadoc.io/doc/com.banno/kafka4s_2.13) for more info.

--- a/site/docs/docs/kafka-producers.md
+++ b/site/docs/docs/kafka-producers.md
@@ -5,4 +5,4 @@ title: Kafka Producers
 
 # Using Kafka Producers
 
-Docs coming soon. Check out the [kafka4s Scaladoc](https://www.javadoc.io/doc/com.banno/kafka4s_2.12) for more info.
+Docs coming soon. Check out the [kafka4s Scaladoc](https://www.javadoc.io/doc/com.banno/kafka4s_2.13) for more info.

--- a/site/docs/docs/schema-registry.md
+++ b/site/docs/docs/schema-registry.md
@@ -5,4 +5,4 @@ title: Schema Registry Utils
 
 # Schema Registry Utils
 
-Docs coming soon. Check out the [kafka4s Scaladoc](https://www.javadoc.io/doc/com.banno/kafka4s_2.12) for more info.
+Docs coming soon. Check out the [kafka4s Scaladoc](https://www.javadoc.io/doc/com.banno/kafka4s_2.13) for more info.

--- a/site/docs/index.md
+++ b/site/docs/index.md
@@ -9,7 +9,7 @@ kafka4s provides pure, referentially transparent functions for working with Kafk
 
 ## Quick Start
 
-To use kafka4s in an existing SBT project with Scala 2.12 or a later version, add the following dependencies to your
+To use kafka4s in an existing SBT project with Scala 2.13 or a later version, add the following dependencies to your
 `build.sbt` depending on your needs:
 
 ```scala


### PR DESCRIPTION
[KAYAK-887]

* Remove unused imports after turning warnings for that back on
* Drop support for cross-compiling on 3.0.0-RC1 since we weren't using it
* Mark myself as a recognized contributor
* Use Scala 2.13.5 consistently rather than 2.13.4 in some places
* Drop Scala formatting

[KAYAK-887]: https://banno-jha.atlassian.net/browse/KAYAK-887