### PR TITLE
feat(consumer): drop `wakeup` from `ConsumerApi`

### DIFF
--- a/core/src/main/scala/com/banno/kafka/consumer/Avro4sConsumerImpl.scala
+++ b/core/src/main/scala/com/banno/kafka/consumer/Avro4sConsumerImpl.scala
@@ -92,5 +92,4 @@ case class Avro4sConsumerImpl[F[_]: Functor, K: FromRecord, V: FromRecord](
     c.subscribe(pattern, callback)
   def subscription: F[Set[String]] = c.subscription
   def unsubscribe: F[Unit] = c.unsubscribe
-  def wakeup: F[Unit] = c.wakeup
 }

--- a/core/src/main/scala/com/banno/kafka/consumer/ConsumerApi.scala
+++ b/core/src/main/scala/com/banno/kafka/consumer/ConsumerApi.scala
@@ -82,7 +82,6 @@ trait ConsumerApi[F[_], K, V] {
   def subscribe(pattern: Pattern, callback: ConsumerRebalanceListener): F[Unit]
   def subscription: F[Set[String]]
   def unsubscribe: F[Unit]
-  def wakeup: F[Unit]
 }
 
 object ConsumerApi {

--- a/core/src/main/scala/com/banno/kafka/consumer/ConsumerImpl.scala
+++ b/core/src/main/scala/com/banno/kafka/consumer/ConsumerImpl.scala
@@ -159,7 +159,6 @@ case class ConsumerImpl[F[_], K, V](c: Consumer[K, V])(implicit F: Sync[F])
     F.delay(c.subscribe(pattern, callback))
   def subscription: F[Set[String]] = F.delay(c.subscription().asScala.toSet)
   def unsubscribe: F[Unit] = F.delay(c.unsubscribe())
-  def wakeup: F[Unit] = F.delay(c.wakeup())
 }
 
 object ConsumerImpl {

--- a/core/src/main/scala/com/banno/kafka/consumer/ShiftingConsumerImpl.scala
+++ b/core/src/main/scala/com/banno/kafka/consumer/ShiftingConsumerImpl.scala
@@ -101,7 +101,6 @@ case class ShiftingConsumerImpl[F[_]: Async, K, V](
     Async[F].evalOn(c.subscribe(pattern, callback), blockingContext)
   def subscription: F[Set[String]] = Async[F].evalOn(c.subscription, blockingContext)
   def unsubscribe: F[Unit] = Async[F].evalOn(c.unsubscribe, blockingContext)
-  def wakeup: F[Unit] = c.wakeup //TODO wakeup is the one method that is thread-safe, right?
 }
 
 object ShiftingConsumerImpl {


### PR DESCRIPTION
Adapted from a conversation I had with @zcox: `wakeup` can be called safely by
any thread, and it will interrupt any operation that single thread is currently
performing. We used to rely on wakeup, but stopped using it once we had
`ShiftingConsumerImpl`. `wakeup` has nothing to do with reading records from
Kafka or committing offsets; It’s to help users deal with concurrency when using
the non-threadsafe Java client. Its presence on the interface is an
inconsistency in the level of abstraction; for us to expose it is to leak a
detail of the underlying Java client that is not relevant to the Scala code.
Moreover, it becomes possible to write all of `ShiftingConsumerImpl` as a
`.mapK` when we remove this odd man out (subsequent PR).