### PR TITLE
Seek operations

### DIFF
--- a/core/src/main/scala/com/banno/kafka/Publish.scala
+++ b/core/src/main/scala/com/banno/kafka/Publish.scala
@@ -45,7 +45,8 @@ object Publish {
   }
 
   object Builder {
-    implicit def buildNPublishers[F[_]: Functor, K, V, X <: Coproduct, Y <: Coproduct](implicit
+    implicit def buildNPublishers[F[_]: Functor, K, V, X <: Coproduct, Y <: Coproduct](
+        implicit
         buildTail: Builder[F, X, Y]
     ) =
       new Builder[F, IncomingRecord[K, V] :+: X, (K, V) :+: Y] {

--- a/core/src/main/scala/com/banno/kafka/RecordStream.scala
+++ b/core/src/main/scala/com/banno/kafka/RecordStream.scala
@@ -324,16 +324,16 @@ object RecordStream {
     ): Resource[F, ConsumerApi[F, GenericRecord, GenericRecord]] = {
       val configs: List[(String, AnyRef)] =
         whetherCommits.configs ++
-        extraConfigs ++
-        List(
-          kafkaBootstrapServers,
-          schemaRegistryUri,
-          EnableAutoCommit(false),
-          reset,
-          IsolationLevel.ReadCommitted,
-          ClientId(clientId),
-          MetricReporters[ConsumerPrometheusReporter],
-        )
+          extraConfigs ++
+          List(
+            kafkaBootstrapServers,
+            schemaRegistryUri,
+            EnableAutoCommit(false),
+            reset,
+            IsolationLevel.ReadCommitted,
+            ClientId(clientId),
+            MetricReporters[ConsumerPrometheusReporter],
+          )
       ConsumerApi.Avro.Generic.resource[F](configs: _*)
     }
   }

--- a/core/src/main/scala/com/banno/kafka/Topic.scala
+++ b/core/src/main/scala/com/banno/kafka/Topic.scala
@@ -118,14 +118,16 @@ object Topic {
         ).configs(purpose.configs.toMap.asJava)
 
       override def registerSchemas[F[_]: Sync](
-        schemaRegistryUri: SchemaRegistryUrl,
-        configs: Map[String, Object] = Map.empty,
+          schemaRegistryUri: SchemaRegistryUrl,
+          configs: Map[String, Object] = Map.empty,
       ): F[Unit] =
-        SchemaRegistryApi.register[F, K, V](
-          schemaRegistryUri.url,
-          topic,
-          configs,
-        ).void
+        SchemaRegistryApi
+          .register[F, K, V](
+            schemaRegistryUri.url,
+            topic,
+            configs,
+          )
+          .void
 
       override def setUp[F[_]: Sync](
           bootstrapServers: BootstrapServers,
@@ -161,8 +163,8 @@ object Topic {
           ) = cr.metadata.nextOffset
 
           override def registerSchemas[F[_]: Sync](
-            schemaRegistryUri: SchemaRegistryUrl,
-            configs: Map[String, Object] = Map.empty,
+              schemaRegistryUri: SchemaRegistryUrl,
+              configs: Map[String, Object] = Map.empty,
           ): F[Unit] = fa.registerSchemas(schemaRegistryUri, configs)
 
           override def setUp[F[_]: Sync](

--- a/core/src/main/scala/com/banno/kafka/TopicPurpose.scala
+++ b/core/src/main/scala/com/banno/kafka/TopicPurpose.scala
@@ -78,9 +78,9 @@ object TopicPurpose {
   val smallState: TopicPurpose =
     lowScale(
       cleanupPolicy(compact) |+|
-      minCleanableDirtyRatio(0.01) |+|
-      segmentMegabytes(1) |+|
-      segmentDuration(10.minutes),
+        minCleanableDirtyRatio(0.01) |+|
+        segmentMegabytes(1) |+|
+        segmentDuration(10.minutes),
       TopicContentType.State
     )
 
@@ -89,9 +89,9 @@ object TopicPurpose {
   val mediumState: TopicPurpose =
     lowScale(
       cleanupPolicy(compact) |+|
-      minCleanableDirtyRatio(0.10) |+|
-      segmentMegabytes(100) |+|
-      segmentDuration(1.day),
+        minCleanableDirtyRatio(0.10) |+|
+        segmentMegabytes(100) |+|
+        segmentDuration(1.day),
       TopicContentType.State
     )
 

--- a/core/src/main/scala/com/banno/kafka/Topical.scala
+++ b/core/src/main/scala/com/banno/kafka/Topical.scala
@@ -53,7 +53,7 @@ trait Topical[A, B] {
   ): F[Unit]
 
   def registerSchemas[F[_]: Sync](
-    schemaRegistryUri: SchemaRegistryUrl,
-    configs: Map[String, Object] = Map.empty,
+      schemaRegistryUri: SchemaRegistryUrl,
+      configs: Map[String, Object] = Map.empty,
   ): F[Unit]
 }

--- a/core/src/main/scala/com/banno/kafka/Topics.scala
+++ b/core/src/main/scala/com/banno/kafka/Topics.scala
@@ -54,8 +54,8 @@ object Topics {
     ): F[Unit]
 
     def tailRegisterSchemas[F[_]: Sync](
-      schemaRegistryUri: SchemaRegistryUrl,
-      configs: Map[String, Object],
+        schemaRegistryUri: SchemaRegistryUrl,
+        configs: Map[String, Object],
     ): F[Unit]
 
     final override def nextOffset(x: IncomingRecord[K, V] :+: S) =
@@ -72,11 +72,11 @@ object Topics {
       kv.eliminate(topic.coparse, tailCoparse)
 
     override def registerSchemas[F[_]: Sync](
-      schemaRegistryUri: SchemaRegistryUrl,
-      configs: Map[String, Object] = Map.empty,
+        schemaRegistryUri: SchemaRegistryUrl,
+        configs: Map[String, Object] = Map.empty,
     ): F[Unit] =
       topic.registerSchemas(schemaRegistryUri, configs) *>
-      tailRegisterSchemas(schemaRegistryUri, configs)
+        tailRegisterSchemas(schemaRegistryUri, configs)
 
     final override def setUp[F[_]: Sync](
         bootstrapServers: BootstrapServers,
@@ -84,7 +84,7 @@ object Topics {
         configs: Map[String, Object] = Map.empty,
     ): F[Unit] =
       topic.setUp(bootstrapServers, schemaRegistryUri, configs) *>
-      tailSetUp(bootstrapServers, schemaRegistryUri, configs)
+        tailSetUp(bootstrapServers, schemaRegistryUri, configs)
   }
 
   private final case class SingletonTopics[K, V](
@@ -95,8 +95,8 @@ object Topics {
     override def tailCoparse(kv: CNil) = kv.impossible
     override def tailNextOffset(x: CNil) = x.impossible
     override def tailRegisterSchemas[F[_]: Sync](
-      schemaRegistryUri: SchemaRegistryUrl,
-      configs: Map[String, Object],
+        schemaRegistryUri: SchemaRegistryUrl,
+        configs: Map[String, Object],
     ): F[Unit] = Applicative[F].unit
     override def tailSetUp[F[_]: Sync](
         bootstrapServers: BootstrapServers,
@@ -121,8 +121,8 @@ object Topics {
     override def tailCoparse(kv: T) = tail.coparse(kv)
 
     override def tailRegisterSchemas[F[_]: Sync](
-      schemaRegistryUri: SchemaRegistryUrl,
-      configs: Map[String, Object],
+        schemaRegistryUri: SchemaRegistryUrl,
+        configs: Map[String, Object],
     ): F[Unit] = tail.registerSchemas(schemaRegistryUri, configs)
 
     override def tailSetUp[F[_]: Sync](

--- a/core/src/main/scala/com/banno/kafka/admin/AdminApi.scala
+++ b/core/src/main/scala/com/banno/kafka/admin/AdminApi.scala
@@ -133,9 +133,11 @@ object AdminApi {
       topics: Iterable[NewTopic],
       configs: Map[String, Object] = Map.empty,
   ): F[CreateTopicsResult] =
-    AdminApi.resource[F](
-      Map[String, Object](BootstrapServers(bootstrapServers)) ++ configs
-    ).use(_.createTopicsIdempotent(topics))
+    AdminApi
+      .resource[F](
+        Map[String, Object](BootstrapServers(bootstrapServers)) ++ configs
+      )
+      .use(_.createTopicsIdempotent(topics))
 
   def createTopicsIdempotent[F[_]: Sync](
       bootstrapServers: String,

--- a/core/src/main/scala/com/banno/kafka/configs.scala
+++ b/core/src/main/scala/com/banno/kafka/configs.scala
@@ -79,7 +79,7 @@ object EnableAutoCommit {
 }
 
 object AutoCommitInterval {
-  def apply(d: FiniteDuration): (String, AnyRef) = 
+  def apply(d: FiniteDuration): (String, AnyRef) =
     ConsumerConfig.AUTO_COMMIT_INTERVAL_MS_CONFIG -> d.toMillis.toString
 }
 

--- a/core/src/main/scala/com/banno/kafka/configs.scala
+++ b/core/src/main/scala/com/banno/kafka/configs.scala
@@ -27,6 +27,7 @@ import io.confluent.kafka.serializers.subject.{
   TopicNameStrategy => KTopicNameStrategy,
   TopicRecordNameStrategy => KTopicRecordNameStrategy
 }
+import scala.concurrent.duration.FiniteDuration
 
 //TODO other configs... maybe we could auto generate these somehow?
 
@@ -75,6 +76,11 @@ case class EnableAutoCommit(b: Boolean)
 object EnableAutoCommit {
   implicit def toConfig(eac: EnableAutoCommit): (String, AnyRef) =
     ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG -> eac.b.toString
+}
+
+object AutoCommitInterval {
+  def apply(d: FiniteDuration): (String, AnyRef) = 
+    ConsumerConfig.AUTO_COMMIT_INTERVAL_MS_CONFIG -> d.toMillis.toString
 }
 
 case class KeySerializerClass(c: Class[?])

--- a/core/src/main/scala/com/banno/kafka/consumer/ConsumerOps.scala
+++ b/core/src/main/scala/com/banno/kafka/consumer/ConsumerOps.scala
@@ -37,6 +37,7 @@ sealed trait SeekTo
 case object SeekToBeginning extends SeekTo
 case object SeekToEnd extends SeekTo
 case class SeekToTimestamps(timestamps: Map[TopicPartition, Long], default: SeekTo) extends SeekTo
+case class SeekToTimestamp(timestamp: Long, default: SeekTo) extends SeekTo
 
 object SeekTo {
   def seek[F[_]: Monad](
@@ -61,6 +62,9 @@ object SeekTo {
                 .fold(SeekTo.seek(consumer, List(p), default))(o => consumer.seek(p, o.offset))
           )
         } yield ()
+      case SeekToTimestamp(timestamp, default) => 
+        val timestamps = partitions.map(p => (p, timestamp)).toMap
+        seek(consumer, partitions, SeekToTimestamps(timestamps, default))
     }
 }
 

--- a/core/src/main/scala/com/banno/kafka/schemaregistry/SchemaRegistryApi.scala
+++ b/core/src/main/scala/com/banno/kafka/schemaregistry/SchemaRegistryApi.scala
@@ -86,10 +86,11 @@ object SchemaRegistryApi {
     Sync[F].delay(new CachedSchemaRegistryClient(restService, identityMapCapacity))
 
   def apply[F[_]: Sync](
-    baseUrl: String,
-    configs: Map[String, Object] = Map.empty,
+      baseUrl: String,
+      configs: Map[String, Object] = Map.empty,
   ): F[SchemaRegistryApi[F]] =
-    createClient[F](baseUrl, identityMapCapacity = 1024, configs = configs).map(SchemaRegistryImpl[F](_))
+    createClient[F](baseUrl, identityMapCapacity = 1024, configs = configs)
+      .map(SchemaRegistryImpl[F](_))
   def apply[F[_]: Sync](baseUrl: String, identityMapCapacity: Int): F[SchemaRegistryApi[F]] =
     createClient[F](baseUrl, identityMapCapacity).map(SchemaRegistryImpl[F](_))
   def apply[F[_]: Sync](baseUrls: Seq[String], identityMapCapacity: Int): F[SchemaRegistryApi[F]] =
@@ -101,9 +102,9 @@ object SchemaRegistryApi {
     createClient[F](restService, identityMapCapacity).map(SchemaRegistryImpl[F](_))
 
   def register[F[_]: Sync, K: SchemaFor, V: SchemaFor](
-    baseUrl: String,
-    topic: String,
-    configs: Map[String, Object] = Map.empty,
+      baseUrl: String,
+      topic: String,
+      configs: Map[String, Object] = Map.empty,
   ) =
     for {
       schemaRegistry <- apply(baseUrl, configs)

--- a/core/src/test/scala/com/banno/kafka/metrics/PrometheusMetricsReporterApiSpec.scala
+++ b/core/src/test/scala/com/banno/kafka/metrics/PrometheusMetricsReporterApiSpec.scala
@@ -97,9 +97,8 @@ class PrometheusMetricsReporterApiSpec extends AnyFlatSpec with Matchers with In
             )
       )
       .unsafeRunSync()
-      CollectorRegistry.defaultRegistry
-        .metricFamilySamples.asScala
-        .count(_.name.startsWith("kafka_producer")) should ===(0)
+    CollectorRegistry.defaultRegistry.metricFamilySamples.asScala
+      .count(_.name.startsWith("kafka_producer")) should ===(0)
   }
 
 }


### PR DESCRIPTION
Refactors `SeekTo`, and adds new seek-related consumer operations:
- `seekToCommittedOr`
- `assignAndSeekToCommittedOr`
- `subscribeAndSeekToCommittedOr`

These operations will allow applications to perform more complex seeking behavior when there are no committed offsets for the consumer's group than just earliest or latest, e.g. "if no committed offsets then seek to offsets closest to this timestamp".

Also adds the `AutoCommitInterval` config helper.