### PR TITLE
feat: fluent assignment interface for `RecordStream` (-> `master`)

### DIFF
--- a/core/src/main/scala/com/banno/kafka/RecordStream.scala
+++ b/core/src/main/scala/com/banno/kafka/RecordStream.scala
@@ -555,14 +555,19 @@ object RecordStream {
       private def assign[A, B](
           consumer: ConsumerApi[F, GenericRecord, GenericRecord],
           topical: Topical[A, B],
-          offsetsF: Kleisli[F, PartitionQueries[F], Map[TopicPartition, Long]]
+          seekToF: Kleisli[F, PartitionQueries[F], SeekTo]
       ): F[Unit] =
         for {
-          offsets <- offsetsF(consumer.partitionQueries)
-          () <- consumer.assign(topical.names.map(_.show).toList, offsets)
+          seekTo <- seekToF(consumer.partitionQueries)
+          () <- consumer.assignAndSeek(topical.names.map(_.show).toList, seekTo)
           // By definition, no need to ever read old ephemera.
           () <- topical.aschematic.traverse_(ephemeralTopicsSeekToEnd(consumer))
         } yield ()
+
+      private def toSeekToF(
+        offsetsF: Kleisli[F, PartitionQueries[F], Map[TopicPartition, Long]]
+      ): Kleisli[F, PartitionQueries[F], SeekTo] =
+        offsetsF.map(SeekTo.offsets(_, SeekTo.beginning))
 
       override def presentWith[A, B](
           topical: Topical[A, B],
@@ -570,7 +575,7 @@ object RecordStream {
           offsetsF: Kleisli[F, PartitionQueries[F], Map[TopicPartition, Long]]
       ): Resource[F, P[F, IncomingRecords[A]]] =
         baseConfigs.consumerApi(reset).evalMap { consumer =>
-          assign(consumer, topical, offsetsF)
+          assign(consumer, topical, toSeekToF(offsetsF))
             .as(presentImpl(consumer, topical))
         }
 
@@ -579,7 +584,7 @@ object RecordStream {
           offsetsF: Kleisli[F, PartitionQueries[F], Map[TopicPartition, Long]]
       ): Resource[F, PastAndPresent.Batched[F, P, A]] =
         baseConfigs.consumerApi(AutoOffsetReset.earliest).evalMap { consumer =>
-          assign(consumer, topical, offsetsF)
+          assign(consumer, topical, toSeekToF(offsetsF))
             .as(
               whetherCommits.pastAndPresent(
                 history = historyImpl(consumer, topical),
@@ -593,7 +598,7 @@ object RecordStream {
           offsets: Map[TopicPartition, Long],
       ): Resource[F, Stream[F, IncomingRecords[A]]] =
         baseConfigs.consumerApi(AutoOffsetReset.earliest).evalMap { consumer =>
-          assign(consumer, topical, Kleisli.pure(offsets))
+          assign(consumer, topical, toSeekToF(Kleisli.pure(offsets)))
             .as(historyImpl(consumer, topical))
         }
     }


### PR DESCRIPTION
Also step `RecordStream` toward supporting `assignAndSeek`.