### PR TITLE
feat: assign & seek for `RecordStream` as a fluent API (-> `master`)

### DIFF
--- a/core/src/main/scala/com/banno/kafka/RecordStream.scala
+++ b/core/src/main/scala/com/banno/kafka/RecordStream.scala
@@ -281,6 +281,9 @@ object RecordStream {
     ): A =
       seekBy(Kleisli.pure(seekTo))
 
+    final def seekToBeginning: A = seekTo(SeekTo.beginning)
+    final def seekToEnd: A = seekTo(SeekTo.end)
+
     final def offsetsBy(
         offsetsF: Kleisli[F, PartitionQueries[F], Map[TopicPartition, Long]]
     ): A =

--- a/core/src/main/scala/com/banno/kafka/RecordStream.scala
+++ b/core/src/main/scala/com/banno/kafka/RecordStream.scala
@@ -260,6 +260,67 @@ object RecordStream {
       history(topical, Map.empty)
   }
 
+  private def toSeekTo(offsets: Map[TopicPartition, Long]): SeekTo =
+    SeekTo.offsets(offsets, SeekTo.beginning)
+
+  private def toSeekToF[F[_]: Functor](
+    offsetsF: Kleisli[F, PartitionQueries[F], Map[TopicPartition, Long]]
+  ): Kleisli[F, PartitionQueries[F], SeekTo] =
+    offsetsF.map(toSeekTo)
+
+  sealed trait Seeker[F[_], A] {
+    protected implicit val F: Applicative[F]
+
+    final def offsets(
+      offsets: Map[TopicPartition, Long]
+    ): A =
+      seekTo(toSeekTo(offsets))
+
+    final def seekTo(
+      seekTo: SeekTo
+    ): A =
+      seekBy(Kleisli.pure(seekTo))
+
+    final def offsetsBy(
+      offsetsF: Kleisli[F, PartitionQueries[F], Map[TopicPartition, Long]]
+    ): A =
+      seekBy(toSeekToF(offsetsF))
+
+    def seekBy(
+      seekToF: Kleisli[F, PartitionQueries[F], SeekTo]
+    ): A
+  }
+
+  sealed trait StreamSelector[F[_], H[_], P[_[_], _], A] {
+    private[RecordStream] def whetherCommits: WhetherCommits[P]
+
+    def present: H[P[F, A]]
+    def pastAndPresent: H[PastAndPresent[F, P, A]]
+    def history: H[Stream[F, A]]
+
+    final def mapK[HH[_]](f: H ~> HH): StreamSelector[F, HH, P, A] = {
+      val self = this
+      new StreamSelector[F, HH, P, A] {
+        private[RecordStream] def whetherCommits: WhetherCommits[P] =
+          self.whetherCommits
+
+        override def present: HH[P[F, A]] =
+          f(self.present)
+
+        override def pastAndPresent: HH[PastAndPresent[F, P, A]] =
+          f(self.pastAndPresent)
+
+        override def history: HH[Stream[F, A]] =
+          f(self.history)
+      }
+    }
+  }
+
+  type SeekResource[F[_], A] =
+    Seeker[F, Resource[F, A]]
+  type SelectAndSeek[F[_], P[_[_], _], A] =
+    StreamSelector[F, SeekResource[F, *], P, A]
+
   private final case class ChunkedSubscriber[F[_]: Async](
       val batched: Subscriber[F, IncomingRecords],
   ) extends Subscriber[F, Id] {
@@ -327,7 +388,9 @@ object RecordStream {
   }
 
   sealed trait ConfigStage3[P[_[_], _], G[_]] {
-    def assign[F[_]: Async]: Assigner[F, G, P]
+    def assign[F[_]: Async, A](
+        topical: Topical[A, ?]
+    ): SelectAndSeek[F, P, G[A]]
   }
 
   private final case class BaseConfigs[P[_[_], _]](
@@ -337,6 +400,21 @@ object RecordStream {
       whetherCommits: WhetherCommits[P],
       extraConfigs: Seq[(String, AnyRef)] = Seq.empty,
   ) extends ConfigStage2[P] {
+    def consumerApiV2[F[_]: Async]: Resource[F, ConsumerApi[F, GenericRecord, GenericRecord]] = {
+      val configs: List[(String, AnyRef)] =
+      whetherCommits.configs ++
+      extraConfigs ++
+      List(
+          kafkaBootstrapServers,
+          schemaRegistryUri,
+          EnableAutoCommit(false),
+          IsolationLevel.ReadCommitted,
+          ClientId(clientId),
+          MetricReporters[ConsumerPrometheusReporter],
+        )
+      ConsumerApi.Avro.Generic.resource[F](configs: _*)
+    }
+
     def consumerApi[F[_]: Async](
         reset: AutoOffsetReset
     ): Resource[F, ConsumerApi[F, GenericRecord, GenericRecord]] = {
@@ -358,17 +436,25 @@ object RecordStream {
     override def untyped(configs: Seq[(String, AnyRef)]) =
       copy(extraConfigs = configs)
 
-    private def batchedAssign[F[_]: Async]: Assigner[F, IncomingRecords, P] =
-      Batched.AssignerImpl(this)
+    private def batchedAssign[F[_]: Async, A](
+        topical: Topical[A, ?]
+    ): SelectAndSeek[F, P, IncomingRecords[A]] = {
+      val _ = Batched.StreamSelectorImpl(whetherCommits, topical)
+      ???
+    }
 
     override def batched: ConfigStage3[P, IncomingRecords] =
       new ConfigStage3[P, IncomingRecords] {
-        override def assign[F[_]: Async] = batchedAssign
+        override def assign[F[_]: Async, A](
+          topical: Topical[A, ?]
+        ) = batchedAssign(topical)
       }
 
     override val chunked: ConfigStage3[P, Id] =
       new ConfigStage3[P, Id] {
-        override def assign[F[_]: Async] = new ChunkedAssigner(batchedAssign)
+        override def assign[F[_]: Async, A](
+          topical: Topical[A, ?]
+        ) = ???
       }
   }
 
@@ -593,6 +679,66 @@ object RecordStream {
             .as(recordStream(consumer, topical))
         }
     }
+
+    private[RecordStream] type NeedsConsumer[F[_], A] =
+      Function[ConsumerApi[F, GenericRecord, GenericRecord], A]
+
+    private[RecordStream] case class StreamSelectorImpl[F[_]: Async, P[_[_], _], A](
+        whetherCommits: WhetherCommits[P],
+        topical: Topical[A, ?],
+    ) extends StreamSelector[F, NeedsConsumer[F, *], P, IncomingRecords[A]] {
+      override def present: NeedsConsumer[F, P[F, IncomingRecords[A]]] =
+        c => whetherCommits.extrude(recordStream(c, topical))
+
+      override def pastAndPresent: NeedsConsumer[F, PastAndPresent.Batched[F, P, A]] =
+      consumer =>
+        whetherCommits.pastAndPresent(
+          history = history(consumer),
+          present = present(consumer),
+        )
+
+      override def history: NeedsConsumer[F, Stream[F, IncomingRecords[A]]] =
+        _.recordsThroughAssignmentLastOffsetsOrZeros(
+              pollTimeout,
+              10,
+              commitMarkerAdjustment = true
+            )
+            .prefetch
+            .evalMap(parseBatch(topical))
+
+    }
+
+    private def assign[F[_]: Monad, A, B](
+      consumer: ConsumerApi[F, GenericRecord, GenericRecord],
+      topical: Topical[A, B],
+      seekToF: Kleisli[F, PartitionQueries[F], SeekTo],
+    ): F[Unit] =
+      for {
+        seekTo <- seekToF(consumer.partitionQueries)
+        () <- consumer.assignAndSeek(topical.names.map(_.show).toList, seekTo)
+        // By definition, no need to ever read old ephemera.
+        () <- topical.aschematic.traverse_(ephemeralTopicsSeekToEnd(consumer))
+      } yield ()
+
+    private[RecordStream] def assignAndSeek[F[_]: Async, P[_[_], _], X](
+        baseConfigs: BaseConfigs[P],
+        topical: Topical[X, ?],
+    ): SelectAndSeek[F, P, IncomingRecords[X]] =
+      StreamSelectorImpl(baseConfigs.whetherCommits, topical).mapK(
+        new ~>[NeedsConsumer[F, *], SeekResource[F, *]] {
+          override def apply[A](fa: NeedsConsumer[F, A]): SeekResource[F, A] =
+            new Seeker[F, Resource[F, A]] {
+              override implicit val F: Applicative[F] = Applicative[F]
+              override def seekBy(
+                seekToF: Kleisli[F, PartitionQueries[F], SeekTo]
+              ) =
+                baseConfigs.consumerApiV2[F].evalMap { consumer =>
+                  assign(consumer, topical, seekToF)
+                    .as(fa(consumer))
+                }
+            }
+        }
+      )
 
     private[RecordStream] case class AssignerImpl[F[_]: Async, P[_[_], _]](
         baseConfigs: BaseConfigs[P]

--- a/core/src/main/scala/com/banno/kafka/RecordStream.scala
+++ b/core/src/main/scala/com/banno/kafka/RecordStream.scala
@@ -47,11 +47,9 @@ sealed trait RecordStream[F[_], A] {
   def readProcessCommit[B](process: A => F[B]): Stream[F, B]
 }
 
-// TODO: at some point when making breaking changes, rename this to
-// `HistoryAndUnbounded`, and its `present` stream to `unbounded`.
-sealed trait PastAndPresent[F[_], P[_[_], _], A] {
+sealed trait HistoryAndUnbounded[F[_], P[_[_], _], A] {
   def history: Stream[F, A]
-  def present: P[F, A]
+  def unbounded: P[F, A]
 
   protected final def catchUp(f: A => F[Unit])(implicit F: Async[F]): F[Unit] =
     history
@@ -59,68 +57,68 @@ sealed trait PastAndPresent[F[_], P[_[_], _], A] {
       .compile
       .drain
 
-  protected def presentStream: Stream[F, A]
+  protected def unboundedStream: Stream[F, A]
 
   final def catchUpThenStream(
       f: A => F[Unit]
   )(implicit F: Async[F]): F[Stream[F, Unit]] =
-    catchUp(f).map(_ => presentStream.evalMap(f))
+    catchUp(f).map(_ => unboundedStream.evalMap(f))
 }
 
-sealed trait PastAndRecordStream[F[_], A] extends PastAndPresent[F, RecordStream, A] {
+sealed trait HistoryAndRecordStream[F[_], A] extends HistoryAndUnbounded[F, RecordStream, A] {
   def catchUpThenReadProcessCommit(
       f: A => F[Unit]
   ): F[Stream[F, Unit]]
 }
 
-object PastAndPresent {
-  type Incoming[F[_], P[_[_], _], K, V] = PastAndPresent[F, P, IncomingRecord[K, V]]
-  type Batched[F[_], P[_[_], _], A] = PastAndPresent[F, P, IncomingRecords[A]]
+object HistoryAndUnbounded {
+  type Incoming[F[_], P[_[_], _], K, V] = HistoryAndUnbounded[F, P, IncomingRecord[K, V]]
+  type Batched[F[_], P[_[_], _], A] = HistoryAndUnbounded[F, P, IncomingRecords[A]]
 }
 
-object PastAndStream {
-  type T[F[_], A] = PastAndPresent[F, Stream, A]
+object HistoryAndStream {
+  type T[F[_], A] = HistoryAndUnbounded[F, Stream, A]
   type Incoming[F[_], K, V] = T[F, IncomingRecord[K, V]]
   type Batched[F[_], A] = T[F, IncomingRecords[A]]
 
   private final case class Impl[F[_], A](
       history: Stream[F, A],
-      present: Stream[F, A]
-  ) extends PastAndPresent[F, Stream, A] {
-    override protected def presentStream: Stream[F, A] = present
+      unbounded: Stream[F, A]
+  ) extends HistoryAndUnbounded[F, Stream, A] {
+    override protected def unboundedStream: Stream[F, A] =unbounded
   }
 
   def apply[F[_], A](
       history: Stream[F, A],
-      present: Stream[F, A]
+      unbounded: Stream[F, A]
   ): T[F, A] =
-    Impl(history = history, present = present)
+    Impl(history = history, unbounded = unbounded)
 
   object Batched {
     type Incoming[F[_], K, V] = Batched[F, IncomingRecord[K, V]]
   }
 }
 
-object PastAndRecordStream {
-  type Incoming[F[_], K, V] = PastAndRecordStream[F, IncomingRecord[K, V]]
-  type Batched[F[_], A] = PastAndRecordStream[F, IncomingRecords[A]]
+object HistoryAndRecordStream {
+  type Incoming[F[_], K, V] = HistoryAndRecordStream[F, IncomingRecord[K, V]]
+  type Batched[F[_], A] = HistoryAndRecordStream[F, IncomingRecords[A]]
 
   private final case class Impl[F[_]: Async, A](
       history: Stream[F, A],
-      present: RecordStream[F, A]
-  ) extends PastAndRecordStream[F, A] {
-    override protected def presentStream: Stream[F, A] = present.records
+      unbounded: RecordStream[F, A]
+  ) extends HistoryAndRecordStream[F, A] {
+    override protected def unboundedStream: Stream[F, A] = unbounded.records
     override def catchUpThenReadProcessCommit(
         f: A => F[Unit]
     ): F[Stream[F, Unit]] =
-      catchUp(f).map(_ => present.readProcessCommit(f))
+      catchUp(f).map(_ => unbounded.readProcessCommit(f))
   }
 
   def apply[F[_]: Async, A](
       history: Stream[F, A],
-      present: RecordStream[F, A]
-  ): PastAndRecordStream[F, A] =
-    Impl(history = history, present = present)
+      unbounded: RecordStream[F, A]
+  ): HistoryAndRecordStream[F, A] =
+    Impl(history = history, unbounded = unbounded)
 
   object Batched {
     type Incoming[F[_], K, V] = Batched[F, IncomingRecord[K, V]]
@@ -152,10 +150,10 @@ object RecordStream {
         topical: Topical[A, B],
     ): P[F, IncomingRecords[A]] => P[F, A]
 
-    def pastAndPresent[F[_]: Async, A](
+    def historyAndUnbounded[F[_]: Async, A](
         history: Stream[F, A],
-        present: P[F, A]
-    ): PastAndPresent[F, P, A]
+        unbounded: P[F, A]
+    ): HistoryAndUnbounded[F, P, A]
 
     def configs: List[(String, AnyRef)]
   }
@@ -169,10 +167,10 @@ object RecordStream {
       ): Stream[F, IncomingRecords[A]] => Stream[F, A] =
         _.flatMap(chunked)
 
-      override def pastAndPresent[F[_]: Async, A](
+      override def historyAndUnbounded[F[_]: Async, A](
           history: Stream[F, A],
-          present: Stream[F, A]
-      ): PastAndPresent[F, Stream, A] = PastAndStream(history, present)
+          unbounded: Stream[F, A]
+      ): HistoryAndUnbounded[F, Stream, A] = HistoryAndStream(history, unbounded)
 
       override def configs: List[(String, AnyRef)] = List()
     }
@@ -191,10 +189,10 @@ object RecordStream {
             override def records: Stream[F, A] = rs.records.flatMap(chunked)
           }
 
-      override def pastAndPresent[F[_]: Async, A](
+      override def historyAndUnbounded[F[_]: Async, A](
           history: Stream[F, A],
-          present: RecordStream[F, A]
-      ): PastAndPresent[F, RecordStream, A] = PastAndRecordStream(history, present)
+          unbounded: RecordStream[F, A]
+      ): HistoryAndUnbounded[F, RecordStream, A] = HistoryAndRecordStream(history, unbounded)
 
       override def configs: List[(String, AnyRef)] = List(groupId)
     }
@@ -267,7 +265,7 @@ object RecordStream {
     private[RecordStream] implicit val G: Apply[G]
 
     def unbounded: G[P[F, A]]
-    def historyAndUnbounded: G[PastAndPresent[F, P, A]]
+    def historyAndUnbounded: G[HistoryAndUnbounded[F, P, A]]
     def history: G[Stream[F, A]]
 
     final def mapK[H[_]: Apply](f: G ~> H): StreamSelector[F, H, P, A] =
@@ -285,11 +283,11 @@ object RecordStream {
         whetherCommits: WhetherCommits[P],
     )(implicit val F: Async[F], val G: Apply[G])
         extends StreamSelector[F, G, P, A] {
-      override def historyAndUnbounded: G[PastAndPresent[F, P, A]] =
+      override def historyAndUnbounded: G[HistoryAndUnbounded[F, P, A]] =
         history.product(unbounded).map { pp =>
-          whetherCommits.pastAndPresent(
+          whetherCommits.historyAndUnbounded(
             history = pp._1,
-            present = pp._2,
+            unbounded = pp._2,
           )
         }
     }
@@ -544,9 +542,9 @@ object RecordStream {
           commitMarkerAdjustment = true
         ).prefetch
           .evalMap(parseBatch(topical))
-      val present: NeedsConsumer[F, P[F, IncomingRecords[A]]] =
+      val unbounded: NeedsConsumer[F, P[F, IncomingRecords[A]]] =
         c => whetherCommits.extrude(recordStream(c, topical))
-      StreamSelector.Impl(history, present, whetherCommits)
+      StreamSelector.Impl(history, unbounded, whetherCommits)
     }
 
     private def assign[F[_]: Monad, A, B](

--- a/core/src/main/scala/com/banno/kafka/RecordStream.scala
+++ b/core/src/main/scala/com/banno/kafka/RecordStream.scala
@@ -291,41 +291,62 @@ object RecordStream {
     ): A
   }
 
-  object Seeker {
-    implicit def functor[F[_]]: Functor[Seeker[F, *]] =
-      new Functor[Seeker[F, *]] {
+  private object Seeker {
+    final case class Impl[F[_], A](
+      apply: Kleisli[F, PartitionQueries[F], SeekTo] => A
+    )(implicit val F: Applicative[F]) extends Seeker[F, A] {
+      override def seekBy(
+        seekToF: Kleisli[F, PartitionQueries[F], SeekTo]
+      ): A = apply(seekToF)
+    }
+
+    implicit def applyInstance[F[_]]: Apply[Seeker[F, *]] =
+      new Apply[Seeker[F, *]] {
+        override def ap[A, B](
+          ff: Seeker[F, A => B]
+        )(
+          fa: Seeker[F, A]
+        ): Seeker[F, B] =
+          ???
+
         override def map[A, B](fa: Seeker[F, A])(f: A => B): Seeker[F, B] =
-          new Seeker[F, B] {
-            override implicit val F = fa.F
-            override def seekBy(
-                seekToF: Kleisli[F, PartitionQueries[F], SeekTo]
-            ): B = f(fa.seekBy(seekToF))
-          }
+          Impl { (seekToF: Kleisli[F, PartitionQueries[F], SeekTo]) =>
+            f(fa.seekBy(seekToF))
+          }(fa.F)
       }
   }
 
   sealed trait StreamSelector[F[_], G[_], P[_[_], _], A] {
     private[RecordStream] def whetherCommits: WhetherCommits[P]
+    private[RecordStream] implicit val F: Async[F]
+    private[RecordStream] implicit val G: Apply[G]
 
     def present: G[P[F, A]]
     def pastAndPresent: G[PastAndPresent[F, P, A]]
     def history: G[Stream[F, A]]
 
-    final def mapK[H[_]](f: G ~> H): StreamSelector[F, H, P, A] = {
-      val self = this
-      new StreamSelector[F, H, P, A] {
-        private[RecordStream] def whetherCommits: WhetherCommits[P] =
-          self.whetherCommits
+    final def mapK[H[_]: Apply](f: G ~> H): StreamSelector[F, H, P, A] =
+      StreamSelector.Impl(
+        f(history),
+        f(present),
+        whetherCommits,
+      )
+  }
 
-        override val present: H[P[F, A]] =
-          f(self.present)
-
-        override val pastAndPresent: H[PastAndPresent[F, P, A]] =
-          f(self.pastAndPresent)
-
-        override val history: H[Stream[F, A]] =
-          f(self.history)
-      }
+  private object StreamSelector {
+    final case class Impl[F[_], G[_], P[_[_], _], A](
+      history: G[Stream[F, A]],
+      present: G[P[F, A]],
+      whetherCommits: WhetherCommits[P],
+    )(implicit val F: Async[F], val G: Apply[G],
+    ) extends StreamSelector[F, G, P, A] {
+      override def pastAndPresent: G[PastAndPresent[F, P, A]] =
+        history.product(present).map { pp =>
+          whetherCommits.pastAndPresent(
+            history = pp._1,
+            present = pp._2,
+          )
+        }
     }
   }
 
@@ -334,28 +355,16 @@ object RecordStream {
   type SelectAndSeek[F[_], P[_[_], _], A] =
     StreamSelector[F, SeekResource[F, *], P, A]
 
-  private final case class ChunkedSelector[F[_]: Async, G[_]: Functor, P[_[_], _], A, B](
-      batched: StreamSelector[F, G, P, IncomingRecords[A]],
-      topical: Topical[A, B],
-  ) extends StreamSelector[F, G, P, A] {
-    override def whetherCommits = batched.whetherCommits
-
-    override val present: G[P[F, A]] =
-      batched.present
-        .map(whetherCommits.chunk(topical))
-
-    override val pastAndPresent: G[PastAndPresent[F, P, A]] =
-      batched.pastAndPresent
-        .map { pp =>
-          whetherCommits.pastAndPresent(
-            history = pp.history.flatMap(chunked),
-            present = whetherCommits.chunk[F, A, B](topical).apply(pp.present),
-          )
-        }
-
-    override val history: G[Stream[F, A]] =
-      batched.history
-        .map(_.flatMap(chunked))
+  private def chunkedSelector[F[_]: Async, G[_], P[_[_], _], A, B](
+    batched: StreamSelector[F, G, P, IncomingRecords[A]],
+    topical: Topical[A, B],
+  ): StreamSelector[F, G, P, A] = {
+    implicit val ap: Apply[G] = batched.G
+    StreamSelector.Impl(
+      batched.history.map(_.flatMap(chunked)),
+      batched.present.map(batched.whetherCommits.chunk(topical)),
+      batched.whetherCommits,
+    )
   }
 
   private final case class ChunkedSubscriber[F[_]: Async](
@@ -487,12 +496,9 @@ object RecordStream {
         override def assign[F[_]: Async, A](
             topical: Topical[A, ?]
         ) =
-          ChunkedSelector(
+          chunkedSelector(
             batched.assign(topical),
             topical
-          )(
-            Async[F],
-            Seeker.functor.compose,
           )
       }
   }
@@ -722,28 +728,20 @@ object RecordStream {
     private[RecordStream] type NeedsConsumer[F[_], A] =
       Function[ConsumerApi[F, GenericRecord, GenericRecord], A]
 
-    private[RecordStream] case class StreamSelectorImpl[F[_]: Async, P[_[_], _], A](
-        whetherCommits: WhetherCommits[P],
-        topical: Topical[A, ?],
-    ) extends StreamSelector[F, NeedsConsumer[F, *], P, IncomingRecords[A]] {
-      override val present: NeedsConsumer[F, P[F, IncomingRecords[A]]] =
-        c => whetherCommits.extrude(recordStream(c, topical))
-
-      override val pastAndPresent: NeedsConsumer[F, PastAndPresent.Batched[F, P, A]] =
-        consumer =>
-          whetherCommits.pastAndPresent(
-            history = history(consumer),
-            present = present(consumer),
-          )
-
-      override val history: NeedsConsumer[F, Stream[F, IncomingRecords[A]]] =
+    private[RecordStream] def streamSelectorViaConsumer[F[_]: Async, P[_[_], _], A](
+      whetherCommits: WhetherCommits[P],
+      topical: Topical[A, ?],
+    ): StreamSelector[F, NeedsConsumer[F, *], P, IncomingRecords[A]] = {
+      val history: NeedsConsumer[F, Stream[F, IncomingRecords[A]]] =
         _.recordsThroughAssignmentLastOffsetsOrZeros(
           pollTimeout,
           10,
           commitMarkerAdjustment = true
         ).prefetch
           .evalMap(parseBatch(topical))
-
+      val present: NeedsConsumer[F, P[F, IncomingRecords[A]]] =
+        c => whetherCommits.extrude(recordStream(c, topical))
+      StreamSelector.Impl(history, present, whetherCommits)
     }
 
     private def assign[F[_]: Monad, A, B](
@@ -762,7 +760,7 @@ object RecordStream {
         baseConfigs: BaseConfigs[P],
         topical: Topical[X, ?],
     ): SelectAndSeek[F, P, IncomingRecords[X]] =
-      StreamSelectorImpl(baseConfigs.whetherCommits, topical).mapK(
+      streamSelectorViaConsumer(baseConfigs.whetherCommits, topical).mapK(
         new ~>[NeedsConsumer[F, *], SeekResource[F, *]] {
           override def apply[A](fa: NeedsConsumer[F, A]): SeekResource[F, A] =
             new Seeker[F, Resource[F, A]] {
@@ -776,7 +774,7 @@ object RecordStream {
                 }
             }
         }
-      )
+      )(Seeker.applyInstance.compose)
 
     private[RecordStream] case class AssignerImpl[F[_]: Async, P[_[_], _]](
         baseConfigs: BaseConfigs[P]

--- a/core/src/main/scala/com/banno/kafka/RecordStream.scala
+++ b/core/src/main/scala/com/banno/kafka/RecordStream.scala
@@ -307,7 +307,9 @@ object RecordStream {
         )(
           fa: Seeker[F, A]
         ): Seeker[F, B] =
-          ???
+          Impl { (seekToF: Kleisli[F, PartitionQueries[F], SeekTo]) =>
+            ff.seekBy(seekToF)(fa.seekBy(seekToF))
+          }(fa.F)
 
         override def map[A, B](fa: Seeker[F, A])(f: A => B): Seeker[F, B] =
           Impl { (seekToF: Kleisli[F, PartitionQueries[F], SeekTo]) =>

--- a/core/src/main/scala/com/banno/kafka/RecordStream.scala
+++ b/core/src/main/scala/com/banno/kafka/RecordStream.scala
@@ -763,16 +763,13 @@ object RecordStream {
       streamSelectorViaConsumer(baseConfigs.whetherCommits, topical).mapK(
         new ~>[NeedsConsumer[F, *], SeekResource[F, *]] {
           override def apply[A](fa: NeedsConsumer[F, A]): SeekResource[F, A] =
-            new Seeker[F, Resource[F, A]] {
-              override implicit val F: Applicative[F] = Applicative[F]
-              override def seekBy(
-                  seekToF: Kleisli[F, PartitionQueries[F], SeekTo]
-              ) =
+            Seeker.Impl(
+              (seekToF: Kleisli[F, PartitionQueries[F], SeekTo]) =>
                 baseConfigs.consumerApiV2[F].evalMap { consumer =>
                   assign(consumer, topical, seekToF)
-                    .as(fa(consumer))
+                  .as(fa(consumer))
                 }
-            }
+            )
         }
       )(Seeker.applyInstance.compose)
 


### PR DESCRIPTION
In a new fluent interface, so as not to make breaking changes, and to avoid
explosion of overloads and accompanying boilerplate. Some functional acrobatics
are needed, but if I'm not mistaken it should be a pleasure to use.