### PR TITLE
feat: assign & seek for `RecordStream` as a fluent API

### DIFF
--- a/core/src/main/scala/com/banno/kafka/RecordStream.scala
+++ b/core/src/main/scala/com/banno/kafka/RecordStream.scala
@@ -47,6 +47,8 @@ sealed trait RecordStream[F[_], A] {
   def readProcessCommit[B](process: A => F[B]): Stream[F, B]
 }
 
+// TODO: at some point when making breaking changes, rename this to
+// `HistoryAndUnbounded`, and its `present` stream to `unbounded`.
 sealed trait PastAndPresent[F[_], P[_[_], _], A] {
   def history: Stream[F, A]
   def present: P[F, A]
@@ -307,17 +309,8 @@ object RecordStream {
       ): A = apply(seekToF)
     }
 
-    implicit def applyInstance[F[_]]: Apply[Seeker[F, *]] =
-      new Apply[Seeker[F, *]] {
-        override def ap[A, B](
-            ff: Seeker[F, A => B]
-        )(
-            fa: Seeker[F, A]
-        ): Seeker[F, B] =
-          Impl { (seekToF: Kleisli[F, PartitionQueries[F], SeekTo]) =>
-            ff.seekBy(seekToF)(fa.seekBy(seekToF))
-          }(fa.F)
-
+    implicit def functor[F[_]]: Functor[Seeker[F, *]] =
+      new Functor[Seeker[F, *]] {
         override def map[A, B](fa: Seeker[F, A])(f: A => B): Seeker[F, B] =
           Impl { (seekToF: Kleisli[F, PartitionQueries[F], SeekTo]) =>
             f(fa.seekBy(seekToF))
@@ -330,14 +323,14 @@ object RecordStream {
     private[RecordStream] implicit val F: Concurrent[F]
     private[RecordStream] implicit val G: Apply[G]
 
-    def present: G[P[F, A]]
-    def pastAndPresent: G[PastAndPresent[F, P, A]]
+    def unbounded: G[P[F, A]]
+    def historyAndUnbounded: G[PastAndPresent[F, P, A]]
     def history: G[Stream[F, A]]
 
     final def mapK[H[_]: Apply](f: G ~> H): StreamSelector[F, H, P, A] =
       StreamSelector.Impl(
         f(history),
-        f(present),
+        f(unbounded),
         whetherCommits,
       )
   }
@@ -345,12 +338,12 @@ object RecordStream {
   private object StreamSelector {
     final case class Impl[F[_], G[_], P[_[_], _], A](
         history: G[Stream[F, A]],
-        present: G[P[F, A]],
+        unbounded: G[P[F, A]],
         whetherCommits: WhetherCommits[P],
     )(implicit val F: Concurrent[F], val G: Apply[G])
         extends StreamSelector[F, G, P, A] {
-      override def pastAndPresent: G[PastAndPresent[F, P, A]] =
-        history.product(present).map { pp =>
+      override def historyAndUnbounded: G[PastAndPresent[F, P, A]] =
+        history.product(unbounded).map { pp =>
           whetherCommits.pastAndPresent(
             history = pp._1,
             present = pp._2,
@@ -359,10 +352,8 @@ object RecordStream {
     }
   }
 
-  type SeekResource[F[_], A] =
-    Seeker[F, Resource[F, A]]
-  type SelectAndSeek[F[_], P[_[_], _], A] =
-    StreamSelector[F, SeekResource[F, *], P, A]
+  type SeekAndSelect[F[_], P[_[_], _], A] =
+    Seeker[F, StreamSelector[F, Resource[F, *], P, A]]
 
   private def chunkedSelector[F[_]: Concurrent, G[_], P[_[_], _], A, B](
       batched: StreamSelector[F, G, P, IncomingRecords[A]],
@@ -371,7 +362,7 @@ object RecordStream {
     implicit val ap: Apply[G] = batched.G
     StreamSelector.Impl(
       batched.history.map(_.flatMap(chunked)),
-      batched.present.map(batched.whetherCommits.chunk(topical)),
+      batched.unbounded.map(batched.whetherCommits.chunk(topical)),
       batched.whetherCommits,
     )
   }
@@ -436,7 +427,7 @@ object RecordStream {
   }
 
   sealed trait ConfigStage2[P[_[_], _]] {
-    def untyped(configs: Seq[(String, AnyRef)]): ConfigStage2[P]
+    def untypedExtras(configs: Seq[(String, AnyRef)]): ConfigStage2[P]
 
     def batched: ConfigStage3[P, IncomingRecords]
     def chunked: ConfigStage3[P, Id]
@@ -445,7 +436,7 @@ object RecordStream {
   sealed trait ConfigStage3[P[_[_], _], G[_]] {
     def assign[F[_]: Concurrent: ContextShift, A](
         topical: Topical[A, ?]
-    ): SelectAndSeek[F, P, G[A]]
+    ): SeekAndSelect[F, P, G[A]]
   }
 
   private final case class BaseConfigs[P[_[_], _]](
@@ -489,7 +480,7 @@ object RecordStream {
       ConsumerApi.Avro.Generic.resource[F](configs: _*)
     }
 
-    override def untyped(configs: Seq[(String, AnyRef)]) =
+    override def untypedExtras(configs: Seq[(String, AnyRef)]) =
       copy(extraConfigs = configs)
 
     override val batched: ConfigStage3[P, IncomingRecords] = {
@@ -506,9 +497,11 @@ object RecordStream {
         override def assign[F[_]: Concurrent: ContextShift, A](
             topical: Topical[A, ?]
         ) =
-          chunkedSelector(
-            batched.assign(topical),
-            topical
+          Seeker.functor.map(batched.assign(topical))(
+            chunkedSelector(
+              _,
+              topical
+            )
           )
       }
   }
@@ -769,19 +762,18 @@ object RecordStream {
     private[RecordStream] def assignAndSeek[F[_]: Concurrent: ContextShift, P[_[_], _], X](
         baseConfigs: BaseConfigs[P],
         topical: Topical[X, ?],
-    ): SelectAndSeek[F, P, IncomingRecords[X]] =
-      streamSelectorViaConsumer(baseConfigs.whetherCommits, topical).mapK(
-        new ~>[NeedsConsumer[F, *], SeekResource[F, *]] {
-          override def apply[A](fa: NeedsConsumer[F, A]): SeekResource[F, A] =
-            Seeker.Impl(
-              (seekToF: Kleisli[F, PartitionQueries[F], SeekTo]) =>
-                baseConfigs.consumerApiV2[F].evalMap { consumer =>
-                  assign(consumer, topical, seekToF)
-                    .as(fa(consumer))
-                }
-            )
-        }
-      )(Seeker.applyInstance.compose)
+    ): SeekAndSelect[F, P, IncomingRecords[X]] =
+      Seeker.Impl { (seekToF: Kleisli[F, PartitionQueries[F], SeekTo]) =>
+        streamSelectorViaConsumer(baseConfigs.whetherCommits, topical).mapK(
+          new ~>[NeedsConsumer[F, *], Resource[F, *]] {
+            override def apply[A](fa: NeedsConsumer[F, A]): Resource[F, A] =
+              baseConfigs.consumerApiV2[F].evalMap { consumer =>
+                assign(consumer, topical, seekToF)
+                  .as(fa(consumer))
+              }
+          }
+        )
+      }
 
     private[RecordStream] case class AssignerImpl[F[_]: Concurrent: ContextShift, P[_[_], _]](
         baseConfigs: BaseConfigs[P]

--- a/core/src/main/scala/com/banno/kafka/RecordStream.scala
+++ b/core/src/main/scala/com/banno/kafka/RecordStream.scala
@@ -307,7 +307,9 @@ object RecordStream {
         )(
           fa: Seeker[F, A]
         ): Seeker[F, B] =
-          ???
+          Impl { (seekToF: Kleisli[F, PartitionQueries[F], SeekTo]) =>
+            ff.seekBy(seekToF)(fa.seekBy(seekToF))
+          }(fa.F)
 
         override def map[A, B](fa: Seeker[F, A])(f: A => B): Seeker[F, B] =
           Impl { (seekToF: Kleisli[F, PartitionQueries[F], SeekTo]) =>

--- a/core/src/main/scala/com/banno/kafka/RecordStream.scala
+++ b/core/src/main/scala/com/banno/kafka/RecordStream.scala
@@ -209,59 +209,6 @@ object RecordStream {
     ): Resource[F, RecordStream[F, G[A]]]
   }
 
-  sealed trait Assigner[F[_], G[_], P[_[_], _]] {
-    private[RecordStream] def whetherCommits: WhetherCommits[P]
-
-    def presentWith[A, B](
-        topical: Topical[A, B],
-        reset: AutoOffsetReset,
-        offsetsF: Kleisli[F, PartitionQueries[F], Map[TopicPartition, Long]],
-    ): Resource[F, P[F, G[A]]]
-
-    final def present[A, B](
-        topical: Topical[A, B],
-        reset: AutoOffsetReset,
-        offsets: Map[TopicPartition, Long],
-    )(implicit F: Applicative[F]): Resource[F, P[F, G[A]]] =
-      presentWith(topical, reset, Kleisli.pure(offsets))
-
-    final def present[A, B](
-        topical: Topical[A, B]
-    )(implicit F: Applicative[F]): Resource[F, P[F, G[A]]] =
-      present(topical, AutoOffsetReset.earliest, Map.empty)
-
-    def pastAndPresentWith[A, B](
-        topical: Topical[A, B],
-        offsetsF: Kleisli[F, PartitionQueries[F], Map[TopicPartition, Long]],
-    ): Resource[F, PastAndPresent[F, P, G[A]]]
-
-    // If you are interested in the past, then how does AutoOffsetReset.latest
-    // make sense? Omitting the parameter until I see a clear reason for this.
-    final def pastAndPresent[A, B](
-        topical: Topical[A, B],
-        offsets: Map[TopicPartition, Long],
-    )(implicit F: Applicative[F]): Resource[F, PastAndPresent[F, P, G[A]]] =
-      pastAndPresentWith(topical, Kleisli.pure(offsets))
-
-    final def pastAndPresent[A, B](
-        topical: Topical[A, B]
-    )(implicit F: Applicative[F]): Resource[F, PastAndPresent[F, P, G[A]]] =
-      pastAndPresent(topical, Map.empty)
-
-    // If you are only interested in the past, then how does
-    // AutoOffsetReset.latest make sense? Omitting the parameter until I see a
-    // clear reason for this.
-    def history[A, B](
-        topical: Topical[A, B],
-        offsets: Map[TopicPartition, Long],
-    ): Resource[F, Stream[F, G[A]]]
-
-    final def history[A, B](
-        topical: Topical[A, B]
-    ): Resource[F, Stream[F, G[A]]] =
-      history(topical, Map.empty)
-  }
-
   private def toSeekTo(offsets: Map[TopicPartition, Long]): SeekTo =
     SeekTo.offsets(offsets, SeekTo.beginning)
 
@@ -379,42 +326,6 @@ object RecordStream {
       batched
         .to(topical, reset)
         .map(whetherCommits.chunk(topical))
-  }
-
-  private final class ChunkedAssigner[F[_]: Concurrent, P[_[_], _]](
-      val batched: Assigner[F, IncomingRecords, P],
-  ) extends Assigner[F, Id, P] {
-    override def whetherCommits = batched.whetherCommits
-
-    override def presentWith[A, B](
-        topical: Topical[A, B],
-        reset: AutoOffsetReset,
-        offsetsF: Kleisli[F, PartitionQueries[F], Map[TopicPartition, Long]]
-    ): Resource[F, P[F, A]] =
-      batched
-        .presentWith(topical, reset, offsetsF)
-        .map(whetherCommits.chunk(topical))
-
-    override def pastAndPresentWith[A, B](
-        topical: Topical[A, B],
-        offsetsF: Kleisli[F, PartitionQueries[F], Map[TopicPartition, Long]]
-    ): Resource[F, PastAndPresent[F, P, A]] =
-      batched
-        .pastAndPresentWith(topical, offsetsF)
-        .map { pp =>
-          whetherCommits.pastAndPresent(
-            history = pp.history.flatMap(chunked),
-            present = whetherCommits.chunk[F, A, B](topical).apply(pp.present),
-          )
-        }
-
-    override def history[A, B](
-        topical: Topical[A, B],
-        offsets: Map[TopicPartition, Long],
-    ): Resource[F, Stream[F, A]] =
-      batched
-        .history(topical, offsets)
-        .map(_.flatMap(chunked))
   }
 
   sealed trait ConfigStage1 {
@@ -539,27 +450,6 @@ object RecordStream {
         )
     }
 
-  private object ChunkedAssigner {
-    def apply[F[_]: Concurrent: ContextShift, P[_[_], _]](
-        kafkaBootstrapServers: BootstrapServers,
-        schemaRegistryUri: SchemaRegistryUrl,
-        clientId: String,
-        whetherCommits: WhetherCommits[P],
-        extraConfigs: Map[String, AnyRef],
-    ): ChunkedAssigner[F, P] =
-      new ChunkedAssigner(
-        Batched.AssignerImpl(
-          BaseConfigs(
-            kafkaBootstrapServers,
-            schemaRegistryUri,
-            clientId,
-            whetherCommits,
-            extraConfigs.toList
-          )
-        )
-      )
-  }
-
   def subscribe[F[_]: Concurrent: ContextShift](
       kafkaBootstrapServers: BootstrapServers,
       schemaRegistryUri: SchemaRegistryUrl,
@@ -591,89 +481,6 @@ object RecordStream {
       groupId.id,
       groupId,
       extraConfigs: _*,
-    )
-
-  def assign[F[_]: Concurrent: ContextShift](
-      kafkaBootstrapServers: BootstrapServers,
-      schemaRegistryUri: SchemaRegistryUrl,
-      clientId: String,
-  ): Assigner[F, Id, Stream] =
-    ChunkedAssigner(
-      kafkaBootstrapServers,
-      schemaRegistryUri,
-      clientId,
-      WhetherCommits.No,
-      Map.empty,
-    )
-
-  def assign[F[_]: Concurrent: ContextShift](
-      kafkaBootstrapServers: BootstrapServers,
-      schemaRegistryUri: SchemaRegistryUrl,
-      groupId: GroupId,
-  ): Assigner[F, Id, RecordStream] =
-    ChunkedAssigner(
-      kafkaBootstrapServers,
-      schemaRegistryUri,
-      groupId.id,
-      WhetherCommits.May(groupId),
-      Map.empty,
-    )
-
-  def assign[F[_]: Concurrent: ContextShift](
-      kafkaBootstrapServers: BootstrapServers,
-      schemaRegistryUri: SchemaRegistryUrl,
-      clientId: String,
-      groupId: GroupId,
-  ): Assigner[F, Id, RecordStream] =
-    ChunkedAssigner(
-      kafkaBootstrapServers,
-      schemaRegistryUri,
-      clientId,
-      WhetherCommits.May(groupId),
-      Map.empty,
-    )
-
-  def assign[F[_]: Concurrent: ContextShift](
-      kafkaBootstrapServers: BootstrapServers,
-      schemaRegistryUri: SchemaRegistryUrl,
-      clientId: String,
-      extraConfigs: Map[String, AnyRef],
-  ): Assigner[F, Id, Stream] =
-    ChunkedAssigner(
-      kafkaBootstrapServers,
-      schemaRegistryUri,
-      clientId,
-      WhetherCommits.No,
-      extraConfigs,
-    )
-
-  def assign[F[_]: Concurrent: ContextShift](
-      kafkaBootstrapServers: BootstrapServers,
-      schemaRegistryUri: SchemaRegistryUrl,
-      groupId: GroupId,
-      extraConfigs: Map[String, AnyRef],
-  ): Assigner[F, Id, RecordStream] =
-    ChunkedAssigner(
-      kafkaBootstrapServers,
-      schemaRegistryUri,
-      groupId.id,
-      WhetherCommits.May(groupId),
-      extraConfigs,
-    )
-
-  def assign[F[_]: Concurrent: ContextShift](
-      kafkaBootstrapServers: BootstrapServers,
-      schemaRegistryUri: SchemaRegistryUrl,
-      clientId: String,
-      groupId: GroupId,
-      extraConfigs: Map[String, AnyRef],
-  ): Assigner[F, Id, RecordStream] =
-    ChunkedAssigner(
-      kafkaBootstrapServers,
-      schemaRegistryUri,
-      clientId,
-      WhetherCommits.May(groupId),
-      extraConfigs,
     )
 
   private def ephemeralTopicsSeekToEnd[F[_]: Monad](
@@ -775,81 +582,6 @@ object RecordStream {
         )
       }
 
-    private[RecordStream] case class AssignerImpl[F[_]: Concurrent: ContextShift, P[_[_], _]](
-        baseConfigs: BaseConfigs[P]
-    ) extends Assigner[F, IncomingRecords, P] {
-      override def whetherCommits = baseConfigs.whetherCommits
-
-      private def historyImpl[A, B](
-          consumer: ConsumerApi[F, GenericRecord, GenericRecord],
-          topical: Topical[A, B],
-      ): Stream[F, IncomingRecords[A]] =
-        consumer
-          .recordsThroughAssignmentLastOffsetsOrZeros(
-            pollTimeout,
-            10,
-            commitMarkerAdjustment = true
-          )
-          .prefetch
-          .evalMap(parseBatch(topical))
-
-      private def presentImpl[A, B](
-          consumer: ConsumerApi[F, GenericRecord, GenericRecord],
-          topical: Topical[A, B],
-      ): P[F, IncomingRecords[A]] =
-        whetherCommits.extrude(recordStream(consumer, topical))
-
-      private def assign[A, B](
-          consumer: ConsumerApi[F, GenericRecord, GenericRecord],
-          topical: Topical[A, B],
-          seekToF: Kleisli[F, PartitionQueries[F], SeekTo]
-      ): F[Unit] =
-        for {
-          seekTo <- seekToF(PartitionQueries(consumer))
-          () <- consumer.assignAndSeek(topical.names.map(_.show).toList, seekTo)
-          // By definition, no need to ever read old ephemera.
-          () <- topical.aschematic.traverse_(ephemeralTopicsSeekToEnd(consumer))
-        } yield ()
-
-      private def toSeekToF(
-          offsetsF: Kleisli[F, PartitionQueries[F], Map[TopicPartition, Long]]
-      ): Kleisli[F, PartitionQueries[F], SeekTo] =
-        offsetsF.map(SeekTo.offsets(_, SeekTo.beginning))
-
-      override def presentWith[A, B](
-          topical: Topical[A, B],
-          reset: AutoOffsetReset,
-          offsetsF: Kleisli[F, PartitionQueries[F], Map[TopicPartition, Long]]
-      ): Resource[F, P[F, IncomingRecords[A]]] =
-        baseConfigs.consumerApi(reset).evalMap { consumer =>
-          assign(consumer, topical, toSeekToF(offsetsF))
-            .as(presentImpl(consumer, topical))
-        }
-
-      override def pastAndPresentWith[A, B](
-          topical: Topical[A, B],
-          offsetsF: Kleisli[F, PartitionQueries[F], Map[TopicPartition, Long]]
-      ): Resource[F, PastAndPresent.Batched[F, P, A]] =
-        baseConfigs.consumerApi(AutoOffsetReset.earliest).evalMap { consumer =>
-          assign(consumer, topical, toSeekToF(offsetsF))
-            .as(
-              whetherCommits.pastAndPresent(
-                history = historyImpl(consumer, topical),
-                present = presentImpl(consumer, topical),
-              )
-            )
-        }
-
-      override def history[A, B](
-          topical: Topical[A, B],
-          offsets: Map[TopicPartition, Long],
-      ): Resource[F, Stream[F, IncomingRecords[A]]] =
-        baseConfigs.consumerApi(AutoOffsetReset.earliest).evalMap { consumer =>
-          assign(consumer, topical, toSeekToF(Kleisli.pure(offsets)))
-            .as(historyImpl(consumer, topical))
-        }
-    }
-
     def subscribe[F[_]: Concurrent: ContextShift](
         kafkaBootstrapServers: BootstrapServers,
         schemaRegistryUri: SchemaRegistryUrl,
@@ -876,98 +608,6 @@ object RecordStream {
           schemaRegistryUri,
           clientId,
           WhetherCommits.May(groupId),
-        )
-      )
-
-    def assign[F[_]: Concurrent: ContextShift](
-        kafkaBootstrapServers: BootstrapServers,
-        schemaRegistryUri: SchemaRegistryUrl,
-        clientId: String,
-    ): Assigner[F, IncomingRecords, Stream] =
-      AssignerImpl(
-        BaseConfigs(
-          kafkaBootstrapServers,
-          schemaRegistryUri,
-          clientId,
-          WhetherCommits.No,
-        )
-      )
-
-    def assign[F[_]: Concurrent: ContextShift](
-        kafkaBootstrapServers: BootstrapServers,
-        schemaRegistryUri: SchemaRegistryUrl,
-        groupId: GroupId,
-    ): Assigner[F, IncomingRecords, RecordStream] =
-      AssignerImpl(
-        BaseConfigs(
-          kafkaBootstrapServers,
-          schemaRegistryUri,
-          groupId.id,
-          WhetherCommits.May(groupId),
-        )
-      )
-
-    def assign[F[_]: Concurrent: ContextShift](
-        kafkaBootstrapServers: BootstrapServers,
-        schemaRegistryUri: SchemaRegistryUrl,
-        clientId: String,
-        groupId: GroupId,
-    ): Assigner[F, IncomingRecords, RecordStream] =
-      AssignerImpl(
-        BaseConfigs(
-          kafkaBootstrapServers,
-          schemaRegistryUri,
-          clientId,
-          WhetherCommits.May(groupId),
-        )
-      )
-
-    def assign[F[_]: Concurrent: ContextShift](
-        kafkaBootstrapServers: BootstrapServers,
-        schemaRegistryUri: SchemaRegistryUrl,
-        clientId: String,
-        configs: Map[String, AnyRef],
-    ): Assigner[F, IncomingRecords, Stream] =
-      AssignerImpl(
-        BaseConfigs(
-          kafkaBootstrapServers,
-          schemaRegistryUri,
-          clientId,
-          WhetherCommits.No,
-          configs.toList
-        )
-      )
-
-    def assign[F[_]: Concurrent: ContextShift](
-        kafkaBootstrapServers: BootstrapServers,
-        schemaRegistryUri: SchemaRegistryUrl,
-        groupId: GroupId,
-        configs: Map[String, AnyRef],
-    ): Assigner[F, IncomingRecords, RecordStream] =
-      AssignerImpl(
-        BaseConfigs(
-          kafkaBootstrapServers,
-          schemaRegistryUri,
-          groupId.id,
-          WhetherCommits.May(groupId),
-          configs.toList
-        )
-      )
-
-    def assign[F[_]: Concurrent: ContextShift](
-        kafkaBootstrapServers: BootstrapServers,
-        schemaRegistryUri: SchemaRegistryUrl,
-        clientId: String,
-        groupId: GroupId,
-        configs: Map[String, AnyRef],
-    ): Assigner[F, IncomingRecords, RecordStream] =
-      AssignerImpl(
-        BaseConfigs(
-          kafkaBootstrapServers,
-          schemaRegistryUri,
-          clientId,
-          WhetherCommits.May(groupId),
-          configs.toList
         )
       )
   }

--- a/core/src/main/scala/com/banno/kafka/RecordStream.scala
+++ b/core/src/main/scala/com/banno/kafka/RecordStream.scala
@@ -763,16 +763,13 @@ object RecordStream {
       streamSelectorViaConsumer(baseConfigs.whetherCommits, topical).mapK(
         new ~>[NeedsConsumer[F, *], SeekResource[F, *]] {
           override def apply[A](fa: NeedsConsumer[F, A]): SeekResource[F, A] =
-            new Seeker[F, Resource[F, A]] {
-              override implicit val F: Applicative[F] = Applicative[F]
-              override def seekBy(
-                  seekToF: Kleisli[F, PartitionQueries[F], SeekTo]
-              ) =
+            Seeker.Impl(
+              (seekToF: Kleisli[F, PartitionQueries[F], SeekTo]) =>
                 baseConfigs.consumerApiV2[F].evalMap { consumer =>
                   assign(consumer, topical, seekToF)
-                    .as(fa(consumer))
+                  .as(fa(consumer))
                 }
-            }
+            )
         }
       )(Seeker.applyInstance.compose)
 

--- a/core/src/main/scala/com/banno/kafka/RecordStream.scala
+++ b/core/src/main/scala/com/banno/kafka/RecordStream.scala
@@ -264,7 +264,7 @@ object RecordStream {
     SeekTo.offsets(offsets, SeekTo.beginning)
 
   private def toSeekToF[F[_]: Functor](
-    offsetsF: Kleisli[F, PartitionQueries[F], Map[TopicPartition, Long]]
+      offsetsF: Kleisli[F, PartitionQueries[F], Map[TopicPartition, Long]]
   ): Kleisli[F, PartitionQueries[F], SeekTo] =
     offsetsF.map(toSeekTo)
 
@@ -272,45 +272,58 @@ object RecordStream {
     protected implicit val F: Applicative[F]
 
     final def offsets(
-      offsets: Map[TopicPartition, Long]
+        offsets: Map[TopicPartition, Long]
     ): A =
       seekTo(toSeekTo(offsets))
 
     final def seekTo(
-      seekTo: SeekTo
+        seekTo: SeekTo
     ): A =
       seekBy(Kleisli.pure(seekTo))
 
     final def offsetsBy(
-      offsetsF: Kleisli[F, PartitionQueries[F], Map[TopicPartition, Long]]
+        offsetsF: Kleisli[F, PartitionQueries[F], Map[TopicPartition, Long]]
     ): A =
       seekBy(toSeekToF(offsetsF))
 
     def seekBy(
-      seekToF: Kleisli[F, PartitionQueries[F], SeekTo]
+        seekToF: Kleisli[F, PartitionQueries[F], SeekTo]
     ): A
   }
 
-  sealed trait StreamSelector[F[_], H[_], P[_[_], _], A] {
+  object Seeker {
+    implicit def functor[F[_]]: Functor[Seeker[F, *]] =
+      new Functor[Seeker[F, *]] {
+        override def map[A, B](fa: Seeker[F, A])(f: A => B): Seeker[F, B] =
+          new Seeker[F, B] {
+            override implicit val F = fa.F
+            override def seekBy(
+                seekToF: Kleisli[F, PartitionQueries[F], SeekTo]
+            ): B = f(fa.seekBy(seekToF))
+          }
+      }
+  }
+
+  sealed trait StreamSelector[F[_], G[_], P[_[_], _], A] {
     private[RecordStream] def whetherCommits: WhetherCommits[P]
 
-    def present: H[P[F, A]]
-    def pastAndPresent: H[PastAndPresent[F, P, A]]
-    def history: H[Stream[F, A]]
+    def present: G[P[F, A]]
+    def pastAndPresent: G[PastAndPresent[F, P, A]]
+    def history: G[Stream[F, A]]
 
-    final def mapK[HH[_]](f: H ~> HH): StreamSelector[F, HH, P, A] = {
+    final def mapK[H[_]](f: G ~> H): StreamSelector[F, H, P, A] = {
       val self = this
-      new StreamSelector[F, HH, P, A] {
+      new StreamSelector[F, H, P, A] {
         private[RecordStream] def whetherCommits: WhetherCommits[P] =
           self.whetherCommits
 
-        override def present: HH[P[F, A]] =
+        override val present: H[P[F, A]] =
           f(self.present)
 
-        override def pastAndPresent: HH[PastAndPresent[F, P, A]] =
+        override val pastAndPresent: H[PastAndPresent[F, P, A]] =
           f(self.pastAndPresent)
 
-        override def history: HH[Stream[F, A]] =
+        override val history: H[Stream[F, A]] =
           f(self.history)
       }
     }
@@ -320,6 +333,30 @@ object RecordStream {
     Seeker[F, Resource[F, A]]
   type SelectAndSeek[F[_], P[_[_], _], A] =
     StreamSelector[F, SeekResource[F, *], P, A]
+
+  private final case class ChunkedSelector[F[_]: Concurrent, G[_]: Functor, P[_[_], _], A, B](
+      batched: StreamSelector[F, G, P, IncomingRecords[A]],
+      topical: Topical[A, B],
+  ) extends StreamSelector[F, G, P, A] {
+    override def whetherCommits = batched.whetherCommits
+
+    override val present: G[P[F, A]] =
+      batched.present
+        .map(whetherCommits.chunk(topical))
+
+    override val pastAndPresent: G[PastAndPresent[F, P, A]] =
+      batched.pastAndPresent
+        .map { pp =>
+          whetherCommits.pastAndPresent(
+            history = pp.history.flatMap(chunked),
+            present = whetherCommits.chunk[F, A, B](topical).apply(pp.present),
+          )
+        }
+
+    override val history: G[Stream[F, A]] =
+      batched.history
+        .map(_.flatMap(chunked))
+  }
 
   private final case class ChunkedSubscriber[F[_]: Async](
       val batched: Subscriber[F, IncomingRecords],
@@ -362,7 +399,7 @@ object RecordStream {
           )
         }
 
-    def history[A, B](
+    override def history[A, B](
         topical: Topical[A, B],
         offsets: Map[TopicPartition, Long],
     ): Resource[F, Stream[F, A]] =
@@ -388,7 +425,7 @@ object RecordStream {
   }
 
   sealed trait ConfigStage3[P[_[_], _], G[_]] {
-    def assign[F[_]: Concurrent, A](
+    def assign[F[_]: Concurrent: ContextShift, A](
         topical: Topical[A, ?]
     ): SelectAndSeek[F, P, G[A]]
   }
@@ -402,16 +439,16 @@ object RecordStream {
   ) extends ConfigStage2[P] {
     def consumerApiV2[F[_]: Async: ContextShift]: Resource[F, ConsumerApi[F, GenericRecord, GenericRecord]] = {
       val configs: List[(String, AnyRef)] =
-      whetherCommits.configs ++
-      extraConfigs ++
-      List(
-          kafkaBootstrapServers,
-          schemaRegistryUri,
-          EnableAutoCommit(false),
-          IsolationLevel.ReadCommitted,
-          ClientId(clientId),
-          MetricReporters[ConsumerPrometheusReporter],
-        )
+        whetherCommits.configs ++
+          extraConfigs ++
+          List(
+            kafkaBootstrapServers,
+            schemaRegistryUri,
+            EnableAutoCommit(false),
+            IsolationLevel.ReadCommitted,
+            ClientId(clientId),
+            MetricReporters[ConsumerPrometheusReporter],
+          )
       ConsumerApi.Avro.Generic.resource[F](configs: _*)
     }
 
@@ -436,25 +473,27 @@ object RecordStream {
     override def untyped(configs: Seq[(String, AnyRef)]) =
       copy(extraConfigs = configs)
 
-    private def batchedAssign[F[_]: Concurrent, A](
-        topical: Topical[A, ?]
-    ): SelectAndSeek[F, P, IncomingRecords[A]] = {
-      val _ = Batched.StreamSelectorImpl(whetherCommits, topical)
-      ???
-    }
-
-    override def batched: ConfigStage3[P, IncomingRecords] =
+    override val batched: ConfigStage3[P, IncomingRecords] = {
+      val configs = this
       new ConfigStage3[P, IncomingRecords] {
-        override def assign[F[_]: Concurrent, A](
-          topical: Topical[A, ?]
-        ) = batchedAssign(topical)
+        override def assign[F[_]: Concurrent: ContextShift, A](
+            topical: Topical[A, ?]
+        ) = Batched.assignAndSeek(configs, topical)
       }
+    }
 
     override val chunked: ConfigStage3[P, Id] =
       new ConfigStage3[P, Id] {
-        override def assign[F[_]: Concurrent, A](
-          topical: Topical[A, ?]
-        ) = ???
+        override def assign[F[_]: Concurrent: ContextShift, A](
+            topical: Topical[A, ?]
+        ) =
+          ChunkedSelector(
+            batched.assign(topical),
+            topical
+          )(
+            Concurrent[F],
+            Seeker.functor.compose,
+          )
       }
   }
 
@@ -687,31 +726,30 @@ object RecordStream {
         whetherCommits: WhetherCommits[P],
         topical: Topical[A, ?],
     ) extends StreamSelector[F, NeedsConsumer[F, *], P, IncomingRecords[A]] {
-      override def present: NeedsConsumer[F, P[F, IncomingRecords[A]]] =
+      override val present: NeedsConsumer[F, P[F, IncomingRecords[A]]] =
         c => whetherCommits.extrude(recordStream(c, topical))
 
-      override def pastAndPresent: NeedsConsumer[F, PastAndPresent.Batched[F, P, A]] =
-      consumer =>
-        whetherCommits.pastAndPresent(
-          history = history(consumer),
-          present = present(consumer),
-        )
+      override val pastAndPresent: NeedsConsumer[F, PastAndPresent.Batched[F, P, A]] =
+        consumer =>
+          whetherCommits.pastAndPresent(
+            history = history(consumer),
+            present = present(consumer),
+          )
 
-      override def history: NeedsConsumer[F, Stream[F, IncomingRecords[A]]] =
+      override val history: NeedsConsumer[F, Stream[F, IncomingRecords[A]]] =
         _.recordsThroughAssignmentLastOffsetsOrZeros(
-              pollTimeout,
-              10,
-              commitMarkerAdjustment = true
-            )
-            .prefetch
-            .evalMap(parseBatch(topical))
+          pollTimeout,
+          10,
+          commitMarkerAdjustment = true
+        ).prefetch
+          .evalMap(parseBatch(topical))
 
     }
 
     private def assign[F[_]: Monad, A, B](
-      consumer: ConsumerApi[F, GenericRecord, GenericRecord],
-      topical: Topical[A, B],
-      seekToF: Kleisli[F, PartitionQueries[F], SeekTo],
+        consumer: ConsumerApi[F, GenericRecord, GenericRecord],
+        topical: Topical[A, B],
+        seekToF: Kleisli[F, PartitionQueries[F], SeekTo],
     ): F[Unit] =
       for {
         seekTo <- seekToF(PartitionQueries(consumer))
@@ -730,7 +768,7 @@ object RecordStream {
             new Seeker[F, Resource[F, A]] {
               override implicit val F: Applicative[F] = Applicative[F]
               override def seekBy(
-                seekToF: Kleisli[F, PartitionQueries[F], SeekTo]
+                  seekToF: Kleisli[F, PartitionQueries[F], SeekTo]
               ) =
                 baseConfigs.consumerApiV2[F].evalMap { consumer =>
                   assign(consumer, topical, seekToF)


### PR DESCRIPTION
In a new fluent interface, so as not to make breaking changes, and to avoid
explosion of overloads and accompanying boilerplate. Some functional acrobatics
are needed, but if I'm not mistaken it should be a pleasure to use.