### PR TITLE
better batch create operation that returns all results

### DIFF
--- a/core/src/main/scala/com/banno/kafka/admin/AdminOps.scala
+++ b/core/src/main/scala/com/banno/kafka/admin/AdminOps.scala
@@ -36,7 +36,7 @@ case class AdminOps[F[_]](admin: AdminApi[F]) {
   /** Attempts to create all specified topics, and returns the result for each topic name. 
    * Right(()) means the topic was created successfully.
    * Note that if the topic already exists, the result will be Left(TopicExistsException), which makes this operation idempotent for each topic. */
-  def createTopics(newTopics: NewTopic*)(implicit F: Sync[F]): F[Map[String, Either[Throwable, Unit]]] = 
+  def createTopicsAndGetResults(newTopics: NewTopic*)(implicit F: Sync[F]): F[Map[String, Either[Throwable, Unit]]] = 
     for {
       result <- admin.createTopics(newTopics)
       allResults <- result.values().asScala.toList.traverse{case (topic, future) => Sync[F].blocking(future.get()).attempt.map((topic, _))}


### PR DESCRIPTION
This version turns the futures into a proper `F[_]`, blocking until all results are available.