### PR TITLE
KAYAK-1398 Shift to blocking pool inside async callback caller

### DIFF
--- a/core/src/main/scala/com/banno/kafka/producer/ProducerImpl.scala
+++ b/core/src/main/scala/com/banno/kafka/producer/ProducerImpl.scala
@@ -87,7 +87,7 @@ case class ProducerImpl[F[_], K, V](p: Producer[K, V])(implicit F: Async[F])
   /** Similar to sendSync, except the returned F[_] is completed asynchronously, usually on the producer's I/O thread.
     * TODO does this have different blocking semantics than sendSync? */
   def sendAsync(record: ProducerRecord[K, V]): F[RecordMetadata] =
-    F.async_(sendRaw(record, _))
+    F.async(k => F.blocking(sendRaw(record, k)).as(none))
 }
 
 object ProducerImpl {

--- a/core/src/main/scala/com/banno/kafka/producer/ProducerImpl.scala
+++ b/core/src/main/scala/com/banno/kafka/producer/ProducerImpl.scala
@@ -85,7 +85,7 @@ case class ProducerImpl[F[_], K, V](p: Producer[K, V])(implicit F: Async[F])
     F.delay(sendRaw(record)).map(_.get())
 
   /** Similar to sendSync, except the returned F[_] is completed asynchronously, usually on the producer's I/O thread.
-    * TODO does this have different blocking semantics than sendSync? */
+    */
   def sendAsync(record: ProducerRecord[K, V]): F[RecordMetadata] =
     F.async(k => F.blocking(sendRaw(record, k)).as(none))
 }


### PR DESCRIPTION
Related to [KAYAK-1398] and #514. Shift to blocking pool inside async ~callback~ callback _caller_ (is there a name for this?). Untested, hence draft; will want to revisit. The motivation is the following paragraph in the KafkaProducer docs:

>  The buffer.memory controls the total amount of memory available to the producer for buffering. If records are sent faster than they can be transmitted to the server then this buffer space will be exhausted. When the buffer space is exhausted additional send calls will block. The threshold for time to block is determined by max.block.ms after which it throws a TimeoutException. 

IOW, it appears that the enqueuing `send` call itself will block the underlying thread if the producer's buffer is full.

[KAYAK-1398]: https://banno-jha.atlassian.net/browse/KAYAK-1398?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ