### PR TITLE
feat: default to `AutoOffsetReset.none` in `RecordStream`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -152,7 +152,7 @@ lazy val commonSettings = Seq(
   ),
   Test / sourceGenerators += (Test / avroScalaGenerate).taskValue,
   watchSources ++= ((Test / avroSourceDirectories).value ** "*.avdl").get,
-  testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-oS"),
+  Test / testOptions += Tests.Argument(TestFrameworks.ScalaTest, "-oS"),
 )
 
 lazy val contributors = Seq(


### PR DESCRIPTION
This reflects Kayak's latest understanding of the best practice based on a
recent incident with Kafka. It is arguably a semantically breaking change, but
it should be binary compatible. At @zcox's request, I've provided a way to
override this with latest or earliest as necessary.