### PR TITLE
Revert "Update simpleclient to 0.14.1"

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,7 +25,7 @@ val V = new {
   val munitCE3 = "1.0.7"
   val scalatest = "3.2.10"
   val scalatestPlus = "3.2.3.0"
-  val simpleClient = "0.14.1"
+  val simpleClient = "0.11.0"
 }
 
 lazy val kafka4s = project


### PR DESCRIPTION
This reverts commit ebe83bf8913820644969d932503c1d6fb97231b7.

Was getting weird runtime errors from this. Sigh, this is not the first time `simpleclient` has done this to us. Will put in a task to do this upgrade separately at some point.