### PR TITLE
Make timestampBeforeNow pure

### DIFF
--- a/core/src/main/scala/com/banno/kafka/RecordStream.scala
+++ b/core/src/main/scala/com/banno/kafka/RecordStream.scala
@@ -564,7 +564,7 @@ object RecordStream {
       StreamSelector.Impl(hAndU, whetherCommits)
     }
 
-    private def assign[F[_]: Monad, A, B](
+    private def assign[F[_]: Monad: Clock, A, B](
         consumer: ConsumerApi[F, GenericRecord, GenericRecord],
         topical: Topical[A, B],
         seekToF: Kleisli[F, PartitionQueries[F], SeekTo],

--- a/core/src/main/scala/com/banno/kafka/consumer/ConsumerOps.scala
+++ b/core/src/main/scala/com/banno/kafka/consumer/ConsumerOps.scala
@@ -72,18 +72,19 @@ case class ConsumerOps[F[_], K, V](consumer: ConsumerApi[F, K, V]) {
       topics: List[String],
       offsets: Map[TopicPartition, Long],
       seekTo: SeekTo = SeekTo.beginning,
-  )(implicit F: Monad[F]): F[Unit] =
+  )(implicit F: Monad[F], C: Clock[F]): F[Unit] =
     assignAndSeek(topics, SeekTo.offsets(offsets, seekTo))
 
   def assign(topic: String, offsets: Map[TopicPartition, Long])(implicit
-      F: Monad[F]
+      F: Monad[F],
+      C: Clock[F],
   ): F[Unit] =
     assign(List(topic), offsets)
 
   def assignAndSeek(
       topics: List[String],
       seekTo: SeekTo,
-  )(implicit F: Monad[F]): F[Unit] =
+  )(implicit F: Monad[F], C: Clock[F]): F[Unit] =
     for {
       infos <- consumer.partitionsFor(topics)
       partitions = infos.map(_.toTopicPartition)

--- a/core/src/main/scala/com/banno/kafka/consumer/SeekTo.scala
+++ b/core/src/main/scala/com/banno/kafka/consumer/SeekTo.scala
@@ -28,7 +28,7 @@ sealed trait SeekTo
 
 object SeekTo {
   sealed trait Attempt {
-    private[SeekTo] def toOffsets[F[_]: Applicative](
+    private[SeekTo] def toOffsets[F[_]: Monad: Clock](
         queries: PartitionQueries[F],
         partitions: Iterable[TopicPartition],
     ): F[Map[TopicPartition, Long]]
@@ -38,7 +38,7 @@ object SeekTo {
     private case class Timestamps(
         timestamps: Map[TopicPartition, Long]
     ) extends Attempt {
-      override def toOffsets[F[_]: Applicative](
+      override def toOffsets[F[_]: Monad: Clock](
           queries: PartitionQueries[F],
           partitions: Iterable[TopicPartition],
       ): F[Map[TopicPartition, Long]] =
@@ -48,7 +48,7 @@ object SeekTo {
     }
 
     private case class Timestamp(timestamp: Long) extends Attempt {
-      override def toOffsets[F[_]: Applicative](
+      override def toOffsets[F[_]: Monad: Clock](
           queries: PartitionQueries[F],
           partitions: Iterable[TopicPartition],
       ): F[Map[TopicPartition, Long]] =
@@ -56,8 +56,20 @@ object SeekTo {
           .toOffsets(queries, partitions)
     }
 
+    private case class TimestampBeforeNow(duration: FiniteDuration)
+        extends Attempt {
+      override def toOffsets[F[_]: Monad: Clock](
+          queries: PartitionQueries[F],
+          partitions: Iterable[TopicPartition],
+      ): F[Map[TopicPartition, Long]] =
+        Clock[F].realTime.flatMap(now =>
+          timestamp(now.toMillis - duration.toMillis)
+            .toOffsets(queries, partitions)
+        )
+    }
+
     private object Committed extends Attempt {
-      override def toOffsets[F[_]: Applicative](
+      override def toOffsets[F[_]: Monad: Clock](
           queries: PartitionQueries[F],
           partitions: Iterable[TopicPartition],
       ): F[Map[TopicPartition, Long]] =
@@ -69,7 +81,7 @@ object SeekTo {
     private case class Offsets(
         offsets: Map[TopicPartition, Long]
     ) extends Attempt {
-      override def toOffsets[F[_]: Applicative](
+      override def toOffsets[F[_]: Monad: Clock](
           queries: PartitionQueries[F],
           partitions: Iterable[TopicPartition],
       ): F[Map[TopicPartition, Long]] =
@@ -87,10 +99,8 @@ object SeekTo {
     def offsets(offsets: Map[TopicPartition, Long]): Attempt =
       Offsets(offsets)
 
-    def timestampBeforeNow[F[_]: Clock: Functor](
-        duration: FiniteDuration
-    ): F[Attempt] =
-      Clock[F].realTime.map(now => timestamp(now.toMillis - duration.toMillis))
+    def timestampBeforeNow(duration: FiniteDuration): Attempt =
+      TimestampBeforeNow(duration)
   }
 
   sealed trait FinalFallback {
@@ -160,7 +170,7 @@ object SeekTo {
       timestamp(now.toMillis - duration.toMillis, default)
     )
 
-  def seek[F[_]: Monad](
+  def seek[F[_]: Monad: Clock](
       consumer: ConsumerApi[F, _, _],
       partitions: Iterable[TopicPartition],
       seekTo: SeekTo,


### PR DESCRIPTION
It's not super ergonomic to have to do:

```scala
SeekTo
  .timestampBeforeNow(duration, default)
  .flatMap(s =>
    consumer.assignAndSeek(topics, s)
  )
```

If `timestampBeforeNow` were pure, it would just be:

```scala
consumer.assignAndSeek(topics, SeekTo.timestampBeforeNow(duration, default))
```

Currently, this PR is a minimal refactoring to achieve this, but now `Clock` is required in a bunch of places. Maybe this is OK?

This also slightly changes when the `now` timestamp is obtained: previously it was when the `timestamBeforeNow` effect is run, and now it will be when `toOffsets` runs (e.g. called by `assignAndSeek`). I doubt this will matter in practice.