### PR TITLE
KAYAK-1520 use transitive prometheus simpleclient dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,6 @@ val V = new {
   val munitCE3 = "1.0.7"
   val scalatest = "3.2.15"
   val scalatestPlus = "3.2.3.0"
-  val simpleClient = "0.16.0"
 }
 
 lazy val kafka4s = project
@@ -162,7 +161,6 @@ lazy val commonSettings = Seq(
     "org.apache.kafka" % "kafka-clients" % V.kafka,
     "io.confluent" % "kafka-avro-serializer" % V.confluent,
     "com.sksamuel.avro4s" %% "avro4s-core" % V.avro4s,
-    "io.prometheus" % "simpleclient" % V.simpleClient,
     "io.chrisdavenport" %% "epimetheus" % V.epimetheus,
     "org.typelevel" %% "log4cats-slf4j" % V.log4cats,
   ),


### PR DESCRIPTION
[KAYAK-1520] Epimetheus also defines the Prometheus `simpleclient` as a dependency, at version 0.11.0. 

When we explicitly define it at 0.16.0, and kafka4s is used in our services, we end up with some other Prometheus libraries (e.g. `simpleclient_hotspot`) still at 0.11.0. 0.16.0 and 0.11.0 don't seem to mix well, leading to this runtime exception:

```
The Collector exposes the same name multiple times: jvm_classes_loaded
```

It's probably better that kafka4s not explicitly define its own simpleclient dependency.

[KAYAK-1520]: https://banno-jha.atlassian.net/browse/KAYAK-1520?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ