### PR TITLE
fix: referential opaqueness in Avro4s, as illustrated by Vulcan

### DIFF
--- a/avro4s/src/main/scala/TopicObjectAvro4sOps.scala
+++ b/avro4s/src/main/scala/TopicObjectAvro4sOps.scala
@@ -17,34 +17,37 @@
 package com.banno.kafka
 package avro4s
 
+import cats.*
 import com.sksamuel.avro4s.*
 
 object TopicObjectAvro4sOps {
   def apply[
+      F[_]: ApplicativeThrow,
       K: FromRecord: ToRecord: SchemaFor,
       V: FromRecord: ToRecord: SchemaFor,
   ](
       topic: String,
       topicPurpose: TopicPurpose,
-  ): Topic[K, V] =
-    Topic(
+  ): F[Topic[K, V]] =
+    Topic.applyF(
       topic,
       topicPurpose,
-      Schema.avro4s[K],
-      Schema.avro4s[V],
+      Schema.avro4s[F, K],
+      Schema.avro4s[F, V],
     )
 
   def builder[
+      F[_]: ApplicativeThrow,
       K: FromRecord: ToRecord: SchemaFor,
       V: FromRecord: ToRecord: SchemaFor,
   ](
       topic: String,
       topicPurpose: TopicPurpose,
-  ): Topic.Builder[K, V] =
-    Topic.builder(
+  ): F[Topic.Builder[K, V]] =
+    Topic.builderF(
       topic,
       topicPurpose,
-      Schema.avro4s[K],
-      Schema.avro4s[V],
+      Schema.avro4s[F, K],
+      Schema.avro4s[F, V],
     )
 }

--- a/avro4s/src/test/scala/CodecCharacterizationTests.scala
+++ b/avro4s/src/test/scala/CodecCharacterizationTests.scala
@@ -23,6 +23,7 @@ import io.confluent.kafka.schemaregistry.CompatibilityLevel
 import munit.*
 import org.scalacheck.*
 import scala.jdk.CollectionConverters.*
+import scala.util.*
 
 class CodecCharacterizationTests extends ScalaCheckSuite {
   test(
@@ -30,10 +31,10 @@ class CodecCharacterizationTests extends ScalaCheckSuite {
     "whole union's schema"
   ) {
     Prop.forAll { (foolike: Foolike) =>
-      val schema = Schema.avro4s[Foolike]
-      val attempt = schema.unparse(foolike)
+      val trySchema = Schema.avro4s[Try, Foolike]
+      val attempt = trySchema.flatMap(x => x.unparse(foolike).map(x -> _))
       assert(clue(attempt).isSuccess)
-      val record = attempt.toOption.get
+      val (schema, record) = attempt.toOption.get
       val parsedSchema = record.getSchema.asParsedSchema
       val errors = schema.ast.asParsedSchema.isCompatible(
         CompatibilityLevel.BACKWARD_TRANSITIVE,

--- a/core/src/main/scala/com/banno/kafka/Schema.scala
+++ b/core/src/main/scala/com/banno/kafka/Schema.scala
@@ -16,10 +16,12 @@
 
 package com.banno.kafka
 
+import cats.*
+import cats.syntax.all.*
 import io.confluent.kafka.schemaregistry.ParsedSchema
 import io.confluent.kafka.schemaregistry.avro.AvroSchema
-import org.apache.avro.{Schema as JSchema}
 import org.apache.avro.generic.GenericRecord
+import org.apache.avro.{Schema as JSchema}
 import scala.util.Try
 
 final case class Schema[A](
@@ -29,4 +31,13 @@ final case class Schema[A](
 ) {
   def parsed: ParsedSchema =
     new AvroSchema(ast)
+}
+
+object Schema {
+  def tryInit[F[_]: Functor, A](
+      tryAst: F[JSchema],
+      parse: GenericRecord => Try[A],
+      unparse: A => Try[GenericRecord],
+  ): F[Schema[A]] =
+    tryAst.map(Schema(_, parse, unparse))
 }

--- a/core/src/main/scala/com/banno/kafka/Topic.scala
+++ b/core/src/main/scala/com/banno/kafka/Topic.scala
@@ -165,6 +165,14 @@ object Topic {
   ): Topic[K, V] =
     Impl(topic, topicPurpose, None, None, keySchema, valueSchema)
 
+  def applyF[F[_]: Applicative, K, V](
+      topic: String,
+      topicPurpose: TopicPurpose,
+      keySchema: F[Schema[K]],
+      valueSchema: F[Schema[V]],
+  ): F[Topic[K, V]] =
+    (keySchema, valueSchema).mapN(Impl(topic, topicPurpose, None, None, _, _))
+
   sealed trait Builder[K, V] {
     def withKeyParseFailedHandler(
         handle: (GenericRecord, Throwable) => Try[K]
@@ -219,6 +227,16 @@ object Topic {
       valueSchema: Schema[V],
   ): Builder[K, V] =
     BuilderImpl(topic, topicPurpose, none, none, keySchema, valueSchema)
+
+  def builderF[F[_]: Applicative, K, V](
+      topic: String,
+      topicPurpose: TopicPurpose,
+      keySchema: F[Schema[K]],
+      valueSchema: F[Schema[V]],
+  ): F[Builder[K, V]] =
+    (keySchema, valueSchema).mapN(
+      BuilderImpl(topic, topicPurpose, none, none, _, _)
+    )
 
   private final case class InvariantImpl[K, A, B](
       fa: Topic[K, A],

--- a/vulcan/src/main/scala/SchemaObjectVulcanOps.scala
+++ b/vulcan/src/main/scala/SchemaObjectVulcanOps.scala
@@ -30,11 +30,9 @@ object SchemaObjectVulcanOps {
       .liftTo[F]
 
   def apply[F[_]: ApplicativeThrow, A: Codec]: F[Schema[A]] =
-    schema.map(
-      Schema(
-        _,
-        Codec.decodeGenericRecord[Try, A](_),
-        Codec.encodeGenericRecord[Try, A](_),
-      )
+    Schema.tryInit(
+      schema,
+      Codec.decodeGenericRecord[Try, A](_),
+      Codec.encodeGenericRecord[Try, A](_),
     )
 }

--- a/vulcan/src/main/scala/TopicObjectVulcanOps.scala
+++ b/vulcan/src/main/scala/TopicObjectVulcanOps.scala
@@ -19,32 +19,27 @@ package vulcan
 
 import _root_.vulcan.*
 import cats.*
-import cats.syntax.all.*
 
 object TopicObjectVulcanOps {
   def apply[F[_]: ApplicativeThrow, K: Codec, V: Codec](
       topic: String,
       topicPurpose: TopicPurpose,
   ): F[Topic[K, V]] =
-    (Schema.vulcan[F, K], Schema.vulcan[F, V]).mapN(
-      Topic(
-        topic,
-        topicPurpose,
-        _,
-        _,
-      )
+    Topic.applyF(
+      topic,
+      topicPurpose,
+      Schema.vulcan[F, K],
+      Schema.vulcan[F, V],
     )
 
   def builder[F[_]: ApplicativeThrow, K: Codec, V: Codec](
       topic: String,
       topicPurpose: TopicPurpose,
   ): F[Topic.Builder[K, V]] =
-    (Schema.vulcan[F, K], Schema.vulcan[F, V]).mapN(
-      Topic.builder(
-        topic,
-        topicPurpose,
-        _,
-        _,
-      )
+    Topic.builderF(
+      topic,
+      topicPurpose,
+      Schema.vulcan[F, K],
+      Schema.vulcan[F, V],
     )
 }


### PR DESCRIPTION
Note that when a Vulcan Codec tries to generate the schema AST, its type indicates that it can fail. This is true to the semantics; Avro4s does not capture these failures at the type level, but being based on the same Avro Java code underneath, the same things are true of it. We have seen in practice that `SF.schema(DefaultFieldMapper)` can throw; and not only that, but it throws sometimes, and not other times, even with the same code (nondeterminism?). (Perhaps this should be wrapped with a `Sync` rather than just an `ApplicativeThrow`?)