### PR TITLE
KAYAK-3355 Send with nested effects

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -65,7 +65,17 @@ lazy val core = project
     mimaBinaryIssueFilters ++= {
       import com.typesafe.tools.mima.core._
       import com.typesafe.tools.mima.core.ProblemFilters._
-      Seq()
+      Seq(
+        ProblemFilters.exclude[DirectMissingMethodProblem](
+          "com.banno.kafka.producer.ProducerApi.mapK"
+        ),
+        ProblemFilters.exclude[ReversedMissingMethodProblem](
+          "com.banno.kafka.producer.ProducerApi.send"
+        ),
+        ProblemFilters.exclude[DirectMissingMethodProblem](
+          "com.banno.kafka.producer.ProducerImpl.mapK"
+        ),
+      )
     },
   )
   .settings(

--- a/core/src/main/scala/com/banno/kafka/producer/ProducerApi.scala
+++ b/core/src/main/scala/com/banno/kafka/producer/ProducerApi.scala
@@ -87,7 +87,6 @@ trait ProducerApi[F[_], K, V] {
         self.sendSync(record.bimap(f, g))
       override def sendAsync(record: ProducerRecord[A, B]): F[RecordMetadata] =
         self.sendAsync(record.bimap(f, g))
-
       override def send2(record: ProducerRecord[A, B]): F[F[RecordMetadata]] =
         self.send2(record.bimap(f, g))
     }
@@ -129,7 +128,6 @@ trait ProducerApi[F[_], K, V] {
         record.bitraverse(f, g) >>= self.sendSync
       override def sendAsync(record: ProducerRecord[A, B]): F[RecordMetadata] =
         record.bitraverse(f, g) >>= self.sendAsync
-
       override def send2(record: ProducerRecord[A, B]): F[F[RecordMetadata]] =
         record.bitraverse(f, g) >>= self.send2
     }
@@ -162,8 +160,6 @@ trait ProducerApi[F[_], K, V] {
         f(self.sendSync(record))
       override def sendAsync(record: ProducerRecord[K, V]): G[RecordMetadata] =
         f(self.sendAsync(record))
-
-      // TODO is G[G[_]] correct here? is this impl correct? requires G have a Functor, is that cool?
       override def send2(record: ProducerRecord[K, V]): G[G[RecordMetadata]] =
         f(self.send2(record)).map(f(_))
     }

--- a/core/src/main/scala/com/banno/kafka/producer/ProducerApi.scala
+++ b/core/src/main/scala/com/banno/kafka/producer/ProducerApi.scala
@@ -51,7 +51,7 @@ trait ProducerApi[F[_], K, V] {
   def sendAsync(record: ProducerRecord[K, V]): F[RecordMetadata]
 
   // TODO obviously need to rename this
-  def send2(record: ProducerRecord[K, V]): F[F[RecordMetadata]]
+  def send(record: ProducerRecord[K, V]): F[F[RecordMetadata]]
 
   // Cats doesn't have `Bicontravariant`
   final def contrabimap[A, B](f: A => K, g: B => V): ProducerApi[F, A, B] = {
@@ -87,8 +87,8 @@ trait ProducerApi[F[_], K, V] {
         self.sendSync(record.bimap(f, g))
       override def sendAsync(record: ProducerRecord[A, B]): F[RecordMetadata] =
         self.sendAsync(record.bimap(f, g))
-      override def send2(record: ProducerRecord[A, B]): F[F[RecordMetadata]] =
-        self.send2(record.bimap(f, g))
+      override def send(record: ProducerRecord[A, B]): F[F[RecordMetadata]] =
+        self.send(record.bimap(f, g))
     }
   }
 
@@ -128,8 +128,8 @@ trait ProducerApi[F[_], K, V] {
         record.bitraverse(f, g) >>= self.sendSync
       override def sendAsync(record: ProducerRecord[A, B]): F[RecordMetadata] =
         record.bitraverse(f, g) >>= self.sendAsync
-      override def send2(record: ProducerRecord[A, B]): F[F[RecordMetadata]] =
-        record.bitraverse(f, g) >>= self.send2
+      override def send(record: ProducerRecord[A, B]): F[F[RecordMetadata]] =
+        record.bitraverse(f, g) >>= self.send
     }
   }
 
@@ -160,8 +160,8 @@ trait ProducerApi[F[_], K, V] {
         f(self.sendSync(record))
       override def sendAsync(record: ProducerRecord[K, V]): G[RecordMetadata] =
         f(self.sendAsync(record))
-      override def send2(record: ProducerRecord[K, V]): G[G[RecordMetadata]] =
-        f(self.send2(record)).map(f(_))
+      override def send(record: ProducerRecord[K, V]): G[G[RecordMetadata]] =
+        f(self.send(record)).map(f(_))
     }
   }
 }

--- a/core/src/main/scala/com/banno/kafka/producer/ProducerApi.scala
+++ b/core/src/main/scala/com/banno/kafka/producer/ProducerApi.scala
@@ -50,7 +50,6 @@ trait ProducerApi[F[_], K, V] {
   def sendSync(record: ProducerRecord[K, V]): F[RecordMetadata]
   def sendAsync(record: ProducerRecord[K, V]): F[RecordMetadata]
 
-  // TODO obviously need to rename this
   def send(record: ProducerRecord[K, V]): F[F[RecordMetadata]]
 
   // Cats doesn't have `Bicontravariant`

--- a/core/src/main/scala/com/banno/kafka/producer/ProducerImpl.scala
+++ b/core/src/main/scala/com/banno/kafka/producer/ProducerImpl.scala
@@ -25,7 +25,7 @@ import org.apache.kafka.common._
 import org.apache.kafka.clients.consumer._
 import org.apache.kafka.clients.producer._
 import scala.concurrent.Promise
-import scala.util.{Try, Success, Failure}
+import scala.util.Try
 
 case class ProducerImpl[F[_], K, V](p: Producer[K, V])(implicit F: Async[F])
     extends ProducerApi[F, K, V] {
@@ -83,7 +83,7 @@ case class ProducerImpl[F[_], K, V](p: Producer[K, V])(implicit F: Async[F])
         record,
         new Callback() {
           override def onCompletion(rm: RecordMetadata, e: Exception): Unit =
-            if (e == null) callback(Success(rm)) else callback(Failure(e))
+            callback(Option(e).toLeft(rm).toTry)
         },
       )
     ).map(jf => F.delay(jf.cancel(true)).void)

--- a/core/src/main/scala/com/banno/kafka/producer/ProducerImpl.scala
+++ b/core/src/main/scala/com/banno/kafka/producer/ProducerImpl.scala
@@ -72,7 +72,9 @@ case class ProducerImpl[F[_], K, V](p: Producer[K, V])(implicit F: Async[F])
     Some(F.delay(jFuture.cancel(false)).void)
   }
 
-  /** The outer effect sends the record on a blocking context and is cancelable. The inner effect cancels the underlying send. */
+  /** The outer effect sends the record on a blocking context and is cancelable.
+    * The inner effect cancels the underlying send.
+    */
   private def sendRaw2(
       record: ProducerRecord[K, V],
       callback: Try[RecordMetadata] => Unit,
@@ -110,32 +112,32 @@ case class ProducerImpl[F[_], K, V](p: Producer[K, V])(implicit F: Async[F])
     * future.get() call throws an exception. You should use this method if your
     * program should not proceed until Kafka accepts the write, or you need to
     * use the RecordMetadata, or you need to explicitly handle any possible
-    * error. Note that traversing many records with this operation prevents 
-    * the underlying producer from batching multiple records.
+    * error. Note that traversing many records with this operation prevents the
+    * underlying producer from batching multiple records.
     */
   def sendSync(record: ProducerRecord[K, V]): F[RecordMetadata] =
     F.delay(sendRaw(record)).map(_.get())
 
   /** Similar to sendSync, except the returned F[_] is completed asynchronously,
-    * usually on the producer's I/O thread. 
-    * Note that traversing many records with this operation prevents 
-    * the underlying producer from batching multiple records.
+    * usually on the producer's I/O thread. Note that traversing many records
+    * with this operation prevents the underlying producer from batching
+    * multiple records.
     */
   def sendAsync(record: ProducerRecord[K, V]): F[RecordMetadata] =
     F.async(sendRaw(record, _))
 
-  /** The outer effect completes synchronously when the underlying Producer.send call returns. 
-    * This is immediately after the producer
-    * enqueues the record, not after Kafka accepts the write. If the producer's
-    * internal queue is full, it will block until the record can be enqueued (i.e. backpressure).
-    * The outer effect is executed on a blocking context and is cancelable.
-    * The outer effect will only contain an error if the Producer.send
-    * call throws an exception.
-    * The inner effect completes asynchronously after Kafka acknowledges the write, and the
-    * RecordMetadata is available. The inner effect will only contain an error if the write failed.
-    * The inner effect is also cancelable.
-    * With this operation, user code can react to both the producer's initial buffering of the record to be sent, 
-    * and the final result of the write (either success or failure).
+  /** The outer effect completes synchronously when the underlying Producer.send
+    * call returns. This is immediately after the producer enqueues the record,
+    * not after Kafka accepts the write. If the producer's internal queue is
+    * full, it will block until the record can be enqueued (i.e. backpressure).
+    * The outer effect is executed on a blocking context and is cancelable. The
+    * outer effect will only contain an error if the Producer.send call throws
+    * an exception. The inner effect completes asynchronously after Kafka
+    * acknowledges the write, and the RecordMetadata is available. The inner
+    * effect will only contain an error if the write failed. The inner effect is
+    * also cancelable. With this operation, user code can react to both the
+    * producer's initial buffering of the record to be sent, and the final
+    * result of the write (either success or failure).
     */
   def send2(record: ProducerRecord[K, V]): F[F[RecordMetadata]] =
     // inspired by https://github.com/fd4s/fs2-kafka/blob/series/3.x/modules/core/src/main/scala/fs2/kafka/KafkaProducer.scala

--- a/core/src/main/scala/com/banno/kafka/producer/ProducerImpl.scala
+++ b/core/src/main/scala/com/banno/kafka/producer/ProducerImpl.scala
@@ -139,7 +139,7 @@ case class ProducerImpl[F[_], K, V](p: Producer[K, V])(implicit F: Async[F])
     * producer's initial buffering of the record to be sent, and the final
     * result of the write (either success or failure).
     */
-  def send2(record: ProducerRecord[K, V]): F[F[RecordMetadata]] =
+  def send(record: ProducerRecord[K, V]): F[F[RecordMetadata]] =
     // inspired by https://github.com/fd4s/fs2-kafka/blob/series/3.x/modules/core/src/main/scala/fs2/kafka/KafkaProducer.scala
     F.delay(Promise[RecordMetadata]())
       .flatMap { promise =>

--- a/core/src/main/scala/com/banno/kafka/producer/ProducerImpl.scala
+++ b/core/src/main/scala/com/banno/kafka/producer/ProducerImpl.scala
@@ -146,7 +146,6 @@ case class ProducerImpl[F[_], K, V](p: Producer[K, V])(implicit F: Async[F])
         sendRaw2(record, promise.complete)
           .map(cancel =>
             F.fromFutureCancelable(
-              // TODO should this be F.pure? why delay this? could `promise.future` throw?
               F.delay((promise.future, cancel))
             )
           )

--- a/core/src/main/scala/com/banno/kafka/producer/ProducerImpl.scala
+++ b/core/src/main/scala/com/banno/kafka/producer/ProducerImpl.scala
@@ -110,19 +110,33 @@ case class ProducerImpl[F[_], K, V](p: Producer[K, V])(implicit F: Async[F])
     * future.get() call throws an exception. You should use this method if your
     * program should not proceed until Kafka accepts the write, or you need to
     * use the RecordMetadata, or you need to explicitly handle any possible
-    * error.
+    * error. Note that traversing many records with this operation prevents 
+    * the underlying producer from batching multiple records.
     */
   def sendSync(record: ProducerRecord[K, V]): F[RecordMetadata] =
     F.delay(sendRaw(record)).map(_.get())
 
   /** Similar to sendSync, except the returned F[_] is completed asynchronously,
-    * usually on the producer's I/O thread. TODO does this have different
-    * blocking semantics than sendSync?
+    * usually on the producer's I/O thread. 
+    * Note that traversing many records with this operation prevents 
+    * the underlying producer from batching multiple records.
     */
   def sendAsync(record: ProducerRecord[K, V]): F[RecordMetadata] =
     F.async(sendRaw(record, _))
 
-  
+  /** The outer effect completes synchronously when the underlying Producer.send call returns. 
+    * This is immediately after the producer
+    * enqueues the record, not after Kafka accepts the write. If the producer's
+    * internal queue is full, it will block until the record can be enqueued (i.e. backpressure).
+    * The outer effect is executed on a blocking context and is cancelable.
+    * The outer effect will only contain an error if the Producer.send
+    * call throws an exception.
+    * The inner effect completes asynchronously after Kafka acknowledges the write, and the
+    * RecordMetadata is available. The inner effect will only contain an error if the write failed.
+    * The inner effect is also cancelable.
+    * With this operation, user code can react to both the producer's initial buffering of the record to be sent, 
+    * and the final result of the write (either success or failure).
+    */
   def send2(record: ProducerRecord[K, V]): F[F[RecordMetadata]] =
     // inspired by https://github.com/fd4s/fs2-kafka/blob/series/3.x/modules/core/src/main/scala/fs2/kafka/KafkaProducer.scala
     F.delay(Promise[RecordMetadata]())

--- a/core/src/main/scala/com/banno/kafka/producer/ProducerImpl.scala
+++ b/core/src/main/scala/com/banno/kafka/producer/ProducerImpl.scala
@@ -106,6 +106,8 @@ case class ProducerImpl[F[_], K, V](p: Producer[K, V])(implicit F: Async[F])
     */
   def sendAsync(record: ProducerRecord[K, V]): F[RecordMetadata] =
     F.async(sendRaw(record, _))
+
+  def send2(record: ProducerRecord[K, V]): F[F[RecordMetadata]] = ???
 }
 
 object ProducerImpl {

--- a/core/src/test/scala/com/banno/kafka/ProducerSendSpec.scala
+++ b/core/src/test/scala/com/banno/kafka/ProducerSendSpec.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 Jack Henry & Associates, Inc.®
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.banno.kafka
+
+// import org.scalacheck.*
+// import org.scalacheck.magnolia.*
+import org.scalatest.EitherValues
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.propspec.AnyPropSpec
+// import org.scalatestplus.scalacheck.*
+
+class ProducerSendSpec
+    extends AnyPropSpec
+    with Matchers
+    with EitherValues
+    with DockerizedKafkaSpec {
+}

--- a/core/src/test/scala/com/banno/kafka/ProducerSendSpec.scala
+++ b/core/src/test/scala/com/banno/kafka/ProducerSendSpec.scala
@@ -27,5 +27,4 @@ class ProducerSendSpec
     extends AnyPropSpec
     with Matchers
     with EitherValues
-    with DockerizedKafkaSpec {
-}
+    with DockerizedKafkaSpec {}

--- a/core/src/test/scala/com/banno/kafka/ProducerSendSpec.scala
+++ b/core/src/test/scala/com/banno/kafka/ProducerSendSpec.scala
@@ -36,7 +36,7 @@ verify inner effect fails on callback with exception
 verify batching? or sequencing/traversing multiple effects?
 
 verify cancelation?
-*/
+ */
 
 class ProducerSendSpec
     extends AnyPropSpec

--- a/core/src/test/scala/com/banno/kafka/ProducerSendSpec.scala
+++ b/core/src/test/scala/com/banno/kafka/ProducerSendSpec.scala
@@ -31,21 +31,6 @@ import java.util.concurrent.{
   CompletableFuture,
 }
 
-/*
-verify outer effect succeeds as soon as send returns
-verify inner effect succeeds as soon as kafka acks (callback is called/record is written)
-
-verify outer effect fails after max.block.ms
-verify inner effect fails after delivery.timeout.ms
-
-verify outer effect fails on send throw
-verify inner effect fails on callback with exception
-
-verify batching? or sequencing/traversing multiple effects?
-
-verify cancelation?
- */
-
 class ProducerSendSpec extends CatsEffectSuite {
 
   val bootstrapServer = "localhost:9092"

--- a/core/src/test/scala/com/banno/kafka/ProducerSendSpec.scala
+++ b/core/src/test/scala/com/banno/kafka/ProducerSendSpec.scala
@@ -23,6 +23,21 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.propspec.AnyPropSpec
 // import org.scalatestplus.scalacheck.*
 
+/*
+verify outer effect succeeds as soon as send returns
+verify inner effect succeeds as soon as kafka acks (callback is called/record is written)
+
+verify outer effect fails after max.block.ms
+verify inner effect fails after delivery.timeout.ms
+
+verify outer effect fails on send throw
+verify inner effect fails on callback with exception
+
+verify batching? or sequencing/traversing multiple effects?
+
+verify cancelation?
+*/
+
 class ProducerSendSpec
     extends AnyPropSpec
     with Matchers


### PR DESCRIPTION
[KAYAK-3355] Sometimes we need to be down closer to `KafkaProducer.send` but in nice FP Scala ways. That `send` has 2 parts: buffering the record to be sent (with backpressure) and receiving the result of the send. 

An example of a program needing both parts is a data replicator that receives a batch of records from some source system and needs to copy them all to Kafka. It needs to send all records in the source batch to the producer's buffer, so the producer can perform its batching, and needs to know when each source record has been buffered so it can be marked as such. Then it needs to know when all records have been successfully written to Kafka so they can be marked as committed. Or, if some records failed to write, that also needs to be handled.

This PR adds a new send operation that returns two nested effects, one for each of those parts.

TODO
- [x] Properly name `send2`
- [x] Tests

[KAYAK-3355]: https://banno-jha.atlassian.net/browse/KAYAK-3355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ