### PR TITLE
Add Trace to producer

### DIFF
--- a/avro4s/src/main/scala/Avro4sProducer.scala
+++ b/avro4s/src/main/scala/Avro4sProducer.scala
@@ -20,6 +20,7 @@ import cats.effect.*
 import com.banno.kafka.producer.*
 import com.sksamuel.avro4s.ToRecord
 import org.apache.avro.generic.GenericRecord
+import natchez.Trace
 
 object Avro4sProducer {
   def apply[F[_], K, V](
@@ -30,7 +31,7 @@ object Avro4sProducer {
   ): ProducerApi[F, K, V] =
     p.contrabimap(ktr.to, vtr.to)
 
-  def resource[F[_]: Async, K: ToRecord, V: ToRecord](
+  def resource[F[_]: Async: Trace, K: ToRecord, V: ToRecord](
       configs: (String, AnyRef)*
   ): Resource[F, ProducerApi[F, K, V]] =
     ProducerApi.Avro.Generic.resource[F](configs: _*).map(Avro4sProducer(_))

--- a/build.sbt
+++ b/build.sbt
@@ -41,6 +41,7 @@ val V = new {
   val kindProjector = "0.13.2"
   val log4cats = "2.6.0"
   val logback = "1.4.14"
+  val natchez = "0.3.5"
   val scalacheck = "1.17.0"
   val scalacheckEffect = "1.0.4"
   val scalacheckMagnolia = "0.6.0"
@@ -99,6 +100,7 @@ lazy val core = project
       "org.typelevel" %% "cats-laws" % V.cats % Test,
       "org.scalatest" %% "scalatest" % V.scalatest % Test,
       "org.typelevel" %% "discipline-munit" % V.disciplineMunit % Test,
+      "org.tpolecat" %% "natchez-opentelemetry" % V.natchez,
     ),
   )
 

--- a/examples/src/main/scala/example1/ExampleApp.scala
+++ b/examples/src/main/scala/example1/ExampleApp.scala
@@ -28,6 +28,7 @@ import org.apache.kafka.clients.admin.NewTopic
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.common.TopicPartition
 import scala.concurrent.duration.*
+import natchez.Trace.Implicits.noop
 
 final class ExampleApp[F[_]: Async] {
 

--- a/examples/src/main/scala/example2/ExampleApp.scala
+++ b/examples/src/main/scala/example2/ExampleApp.scala
@@ -27,6 +27,7 @@ import org.apache.kafka.clients.admin.NewTopic
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.common.TopicPartition
 import scala.concurrent.duration.*
+import natchez.Trace.Implicits.noop
 
 final class ExampleApp[F[_]: Async] {
 

--- a/examples/src/main/scala/example3/ExampleApp.scala
+++ b/examples/src/main/scala/example3/ExampleApp.scala
@@ -27,6 +27,7 @@ import org.apache.kafka.clients.admin.NewTopic
 import org.apache.kafka.clients.producer.ProducerRecord
 import scala.concurrent.duration._
 import scala.util.Random
+import natchez.Trace.Implicits.noop
 
 final class ExampleApp[F[_]: Async] {
 

--- a/vulcan/src/main/scala/VulcanProducer.scala
+++ b/vulcan/src/main/scala/VulcanProducer.scala
@@ -21,6 +21,7 @@ import cats.effect.*
 import com.banno.kafka.producer.*
 import org.apache.avro.generic.GenericRecord
 import vulcan.*
+import natchez.Trace
 
 object VulcanProducer {
   def apply[F[_]: MonadThrow, K: Codec, V: Codec](
@@ -31,7 +32,7 @@ object VulcanProducer {
       Codec.encodeGenericRecord[F, V](_),
     )
 
-  def resource[F[_]: Async, K: Codec, V: Codec](
+  def resource[F[_]: Async: Trace, K: Codec, V: Codec](
       configs: (String, AnyRef)*
   ): Resource[F, ProducerApi[F, K, V]] =
     ProducerApi.Avro.Generic.resource[F](configs: _*).map(apply(_))


### PR DESCRIPTION
Adds a `kafka-send` trace to sent messages.  Children are `buffer` for the outer effect, and `ack` for the inner effect.