### PR TITLE
Integrate Natchez tracing into producer

### DIFF
--- a/avro4s/src/main/scala/Avro4sProducer.scala
+++ b/avro4s/src/main/scala/Avro4sProducer.scala
@@ -20,6 +20,7 @@ import cats.effect.*
 import com.banno.kafka.producer.*
 import com.sksamuel.avro4s.ToRecord
 import org.apache.avro.generic.GenericRecord
+import natchez.Trace
 
 object Avro4sProducer {
   def apply[F[_], K, V](
@@ -30,7 +31,7 @@ object Avro4sProducer {
   ): ProducerApi[F, K, V] =
     p.contrabimap(ktr.to, vtr.to)
 
-  def resource[F[_]: Async, K: ToRecord, V: ToRecord](
+  def resource[F[_]: Async: Trace, K: ToRecord, V: ToRecord](
       configs: (String, AnyRef)*
   ): Resource[F, ProducerApi[F, K, V]] =
     ProducerApi.Avro.Generic.resource[F](configs: _*).map(Avro4sProducer(_))

--- a/avro4s/src/test/scala/ConsumerAndProducerApiSpec.scala
+++ b/avro4s/src/test/scala/ConsumerAndProducerApiSpec.scala
@@ -24,6 +24,7 @@ import com.banno.kafka.producer.*
 import com.sksamuel.avro4s.RecordFormat
 import fs2.*
 import java.util.ConcurrentModificationException
+import natchez.Trace.Implicits.noop
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.common.TopicPartition
 import org.scalacheck.*

--- a/build.sbt
+++ b/build.sbt
@@ -5,11 +5,7 @@ import org.typelevel.sbt.site.GenericSiteSettings
 
 ThisBuild / scalaVersion := "2.13.10"
 ThisBuild / crossScalaVersions := List(scalaVersion.value)
-ThisBuild / tlBaseVersion := "5.0"
-ThisBuild / tlMimaPreviousVersions ~= { versions =>
-  val failedReleases = Set("5.0.1", "5.0.2")
-  versions -- failedReleases
-}
+ThisBuild / tlBaseVersion := "6.0"
 ThisBuild / githubWorkflowJavaVersions := Seq(JavaSpec.temurin("11"))
 ThisBuild / githubWorkflowTargetBranches := Seq("*", "series/*")
 ThisBuild / githubWorkflowBuildPreamble := Seq(
@@ -67,15 +63,6 @@ lazy val core = project
       import com.typesafe.tools.mima.core._
       import com.typesafe.tools.mima.core.ProblemFilters._
       Seq(
-        ProblemFilters.exclude[DirectMissingMethodProblem](
-          "com.banno.kafka.producer.ProducerApi.mapK"
-        ),
-        ProblemFilters.exclude[ReversedMissingMethodProblem](
-          "com.banno.kafka.producer.ProducerApi.send"
-        ),
-        ProblemFilters.exclude[DirectMissingMethodProblem](
-          "com.banno.kafka.producer.ProducerImpl.mapK"
-        ),
       )
     },
   )

--- a/build.sbt
+++ b/build.sbt
@@ -41,6 +41,7 @@ val V = new {
   val kindProjector = "0.13.2"
   val log4cats = "2.6.0"
   val logback = "1.4.14"
+  val natchez = "0.3.5"
   val scalacheck = "1.17.0"
   val scalacheckEffect = "1.0.4"
   val scalacheckMagnolia = "0.6.0"
@@ -96,6 +97,7 @@ lazy val core = project
       "org.typelevel" %% "scalacheck-effect-munit" % V.scalacheckEffect,
       "org.typelevel" %% "munit-cats-effect-3" % V.munitCE3 % Test,
       "org.typelevel" %% "cats-effect" % V.catsEffect,
+      "org.tpolecat" %% "natchez-core" % V.natchez,
       "org.typelevel" %% "cats-laws" % V.cats % Test,
       "org.scalatest" %% "scalatest" % V.scalatest % Test,
       "org.typelevel" %% "discipline-munit" % V.disciplineMunit % Test,

--- a/core/src/test/scala/com/banno/kafka/ProducerSendSpec.scala
+++ b/core/src/test/scala/com/banno/kafka/ProducerSendSpec.scala
@@ -32,6 +32,7 @@ import java.util.concurrent.{
   CompletableFuture,
 }
 import scala.concurrent.duration.*
+import natchez.Trace.Implicits.noop
 
 class ProducerSendSpec extends CatsEffectSuite {
 

--- a/core/src/test/scala/com/banno/kafka/metrics/epimetheus/EpimetheusMetricsReporterApiSpec.scala
+++ b/core/src/test/scala/com/banno/kafka/metrics/epimetheus/EpimetheusMetricsReporterApiSpec.scala
@@ -21,6 +21,7 @@ import cats.effect.IO
 import com.banno.kafka._
 import com.banno.kafka.producer._
 import com.banno.kafka.consumer._
+import natchez.Trace.Implicits.noop
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.common.TopicPartition
 import io.prometheus.client.CollectorRegistry

--- a/examples/src/main/scala/example1/ExampleApp.scala
+++ b/examples/src/main/scala/example1/ExampleApp.scala
@@ -24,6 +24,7 @@ import com.banno.kafka.avro4s.*
 import com.banno.kafka.consumer.*
 import com.banno.kafka.producer.*
 import com.banno.kafka.schemaregistry.*
+import natchez.Trace.Implicits.noop
 import org.apache.kafka.clients.admin.NewTopic
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.common.TopicPartition

--- a/examples/src/main/scala/example2/ExampleApp.scala
+++ b/examples/src/main/scala/example2/ExampleApp.scala
@@ -23,6 +23,7 @@ import com.banno.kafka.admin.*
 import com.banno.kafka.avro4s.*
 import com.banno.kafka.consumer.*
 import com.banno.kafka.schemaregistry.*
+import natchez.Trace.Implicits.noop
 import org.apache.kafka.clients.admin.NewTopic
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.common.TopicPartition

--- a/examples/src/main/scala/example3/ExampleApp.scala
+++ b/examples/src/main/scala/example3/ExampleApp.scala
@@ -23,6 +23,7 @@ import com.banno.kafka._
 import com.banno.kafka.admin._
 import com.banno.kafka.consumer._
 import com.banno.kafka.producer._
+import natchez.Trace.Implicits.noop
 import org.apache.kafka.clients.admin.NewTopic
 import org.apache.kafka.clients.producer.ProducerRecord
 import scala.concurrent.duration._

--- a/site/docs/docs/index.md
+++ b/site/docs/docs/index.md
@@ -98,9 +98,20 @@ We first bring our Kafka producer utils into scope:
 import com.banno.kafka.producer._
 ```
 
+As of kafka4s-6.x, producers are traced with
+[Natchez](https://typelevel.org/natchez/), so an implicit `Trace[IO]`
+is required.  See the [Natchez
+backends](https://typelevel.org/natchez/backends/index.html) for more
+production solutions.
+
+```scala mdoc
+import natchez.Trace.Implicits.noop
+```
+
 Now we can create our producer instance:
 
 ```scala mdoc
+
 val producer = ProducerApi.Avro.Generic.resource[IO](
   BootstrapServers(kafkaBootstrapServers),
   SchemaRegistryUrl(schemaRegistryUri),

--- a/vulcan/src/main/scala/VulcanProducer.scala
+++ b/vulcan/src/main/scala/VulcanProducer.scala
@@ -21,6 +21,7 @@ import cats.effect.*
 import com.banno.kafka.producer.*
 import org.apache.avro.generic.GenericRecord
 import vulcan.*
+import natchez.Trace
 
 object VulcanProducer {
   def apply[F[_]: MonadThrow, K: Codec, V: Codec](
@@ -31,7 +32,7 @@ object VulcanProducer {
       Codec.encodeGenericRecord[F, V](_),
     )
 
-  def resource[F[_]: Async, K: Codec, V: Codec](
+  def resource[F[_]: Async: Trace, K: Codec, V: Codec](
       configs: (String, AnyRef)*
   ): Resource[F, ProducerApi[F, K, V]] =
     ProducerApi.Avro.Generic.resource[F](configs: _*).map(apply(_))


### PR DESCRIPTION
This is a simplified version of #826.  It traces just the outer buffer and inner ack effect, propagating the Natchez kernel.

- The ack is a child of the corresponding buffer
- The ack span will start after the send is complete
- The ack span will not start until the producer's caller sequences it.  This is a metric of how long the producer is waiting for it.  If you want metrics for Kafka's health, look at Kafka.