### PR TITLE
Deprecate more sendSync-adjacent things

### DIFF
--- a/avro4s/src/test/scala/ConsumerAndProducerApiSpec.scala
+++ b/avro4s/src/test/scala/ConsumerAndProducerApiSpec.scala
@@ -183,7 +183,7 @@ class ConsumerAndProducerApiSpec
           )
           .use(c =>
             for {
-              _ <- p.sendSyncBatch(records)
+              _ <- p.sendAsyncBatch(records)
 
               _ <- c.assign(List(tp0, tp1, tp2))
               _ <- c.seekToBeginning(List(tp0))
@@ -199,7 +199,7 @@ class ConsumerAndProducerApiSpec
                 .toList
 
               // consumer must still be usable after stream halts, positioned immediately after all of the records it's already returned
-              _ <- p.sendSync(new ProducerRecord(topic, null, "new"))
+              _ <- p.sendAsync(new ProducerRecord(topic, null, "new"))
               rs <- c.poll(1 second)
 
               _ <- p.close
@@ -236,7 +236,7 @@ class ConsumerAndProducerApiSpec
       _ <- ProducerApi
         .resource[IO, String, String](BootstrapServers(bootstrapServer))
         .use(
-          _.sendSyncBatch(expected.map(s => new ProducerRecord(topic, s, s)))
+          _.sendAsyncBatch(expected.map(s => new ProducerRecord(topic, s, s)))
         )
       consume: Stream[IO, String] = Stream
         .resource(

--- a/core/src/main/scala/com/banno/kafka/producer/ProducerApi.scala
+++ b/core/src/main/scala/com/banno/kafka/producer/ProducerApi.scala
@@ -47,7 +47,10 @@ trait ProducerApi[F[_], K, V] {
   ): F[Unit]
 
   def sendAndForget(record: ProducerRecord[K, V]): F[Unit]
+
+  @deprecated("Use sendAsync, or send in kafka4s-6.x", "5.0.5")
   def sendSync(record: ProducerRecord[K, V]): F[RecordMetadata]
+
   def sendAsync(record: ProducerRecord[K, V]): F[RecordMetadata]
 
   // Cats doesn't have `Bicontravariant`
@@ -80,8 +83,11 @@ trait ProducerApi[F[_], K, V] {
 
       override def sendAndForget(record: ProducerRecord[A, B]): F[Unit] =
         self.sendAndForget(record.bimap(f, g))
+
+      @deprecated("Use sendAsync, or send in kafka4s-6.x", "5.0.5")
       override def sendSync(record: ProducerRecord[A, B]): F[RecordMetadata] =
         self.sendSync(record.bimap(f, g))
+
       override def sendAsync(record: ProducerRecord[A, B]): F[RecordMetadata] =
         self.sendAsync(record.bimap(f, g))
     }
@@ -119,8 +125,11 @@ trait ProducerApi[F[_], K, V] {
 
       override def sendAndForget(record: ProducerRecord[A, B]): F[Unit] =
         record.bitraverse(f, g) >>= self.sendAndForget
+
+      @deprecated("Use sendAsync, or send in kafka4s-6.x", "5.0.5")
       override def sendSync(record: ProducerRecord[A, B]): F[RecordMetadata] =
         record.bitraverse(f, g) >>= self.sendSync
+
       override def sendAsync(record: ProducerRecord[A, B]): F[RecordMetadata] =
         record.bitraverse(f, g) >>= self.sendAsync
     }
@@ -149,8 +158,11 @@ trait ProducerApi[F[_], K, V] {
 
       override def sendAndForget(record: ProducerRecord[K, V]): G[Unit] =
         f(self.sendAndForget(record))
+
+      @deprecated("Use sendAsync, or send in kafka4s-6.x", "5.0.5")
       override def sendSync(record: ProducerRecord[K, V]): G[RecordMetadata] =
         f(self.sendSync(record))
+
       override def sendAsync(record: ProducerRecord[K, V]): G[RecordMetadata] =
         f(self.sendAsync(record))
     }

--- a/core/src/main/scala/com/banno/kafka/producer/ProducerOps.scala
+++ b/core/src/main/scala/com/banno/kafka/producer/ProducerOps.scala
@@ -30,6 +30,7 @@ case class ProducerOps[F[_], K, V](producer: ProducerApi[F, K, V]) {
   )(implicit F: Applicative[F]): F[Unit] =
     records.traverse_(producer.sendAndForget)
 
+  @deprecated("Use sendAsyncBatch", "5.0.5")
   def sendSyncBatch[G[_]: Traverse](
       records: G[ProducerRecord[K, V]]
   )(implicit F: Applicative[F]): F[G[RecordMetadata]] =
@@ -40,6 +41,7 @@ case class ProducerOps[F[_], K, V](producer: ProducerApi[F, K, V]) {
   )(implicit F: Applicative[F]): F[G[RecordMetadata]] =
     records.traverse(producer.sendAsync)
 
+  @deprecated("Use pipeAsync", "5.0.5")
   def pipeSync: Pipe[F, ProducerRecord[K, V], RecordMetadata] =
     _.evalMap(producer.sendSync)
 
@@ -49,6 +51,7 @@ case class ProducerOps[F[_], K, V](producer: ProducerApi[F, K, V]) {
   def sink: Pipe[F, ProducerRecord[K, V], Unit] =
     _.evalMap(producer.sendAndForget)
 
+  @deprecated("Use sinkAsync", "5.0.5")
   def sinkSync: Pipe[F, ProducerRecord[K, V], Unit] =
     pipeSync.apply(_).void
 

--- a/core/src/test/scala/com/banno/kafka/metrics/epimetheus/EpimetheusMetricsReporterApiSpec.scala
+++ b/core/src/test/scala/com/banno/kafka/metrics/epimetheus/EpimetheusMetricsReporterApiSpec.scala
@@ -86,7 +86,7 @@ class EpimetheusMetricsReporterApiSpec
                 )
                 .use(c2 =>
                   for {
-                    _ <- p.sendSyncBatch(records)
+                    _ <- p.sendAsyncBatch(records)
 
                     _ <- c1.assign(topic, Map.empty[TopicPartition, Long])
                     _ <- c1.poll(1 second)

--- a/examples/src/main/scala/example1/ExampleApp.scala
+++ b/examples/src/main/scala/example1/ExampleApp.scala
@@ -82,7 +82,7 @@ final class ExampleApp[F[_]: Async] {
 
       _ <- producerResource.use(producer =>
         producerRecords.traverse_(pr =>
-          producer.sendSync(pr) *> Sync[F]
+          producer.sendAsync(pr) *> Sync[F]
             .delay(
               println(
                 s"Wrote producer record: key ${pr.key} and value ${pr.value}"

--- a/examples/src/main/scala/example2/ExampleApp.scala
+++ b/examples/src/main/scala/example2/ExampleApp.scala
@@ -82,7 +82,7 @@ final class ExampleApp[F[_]: Async] {
       _ <- producer
         .use(producer =>
           producerRecords.traverse_(pr =>
-            producer.sendSync(pr) *> Sync[F]
+            producer.sendAsync(pr) *> Sync[F]
               .delay(
                 println(
                   s"Wrote producer record: key ${pr.key} and value ${pr.value}"

--- a/site/docs/docs/index.md
+++ b/site/docs/docs/index.md
@@ -147,7 +147,7 @@ We can now write our typed customer records successfully!
 ```scala mdoc:compile-only
 import cats.effect.unsafe.implicits.global
 avro4sProducer.use(p =>
-  recordsToBeWritten.traverse_(r => p.sendSync(r).flatMap(rmd => IO(println(s"Wrote record to ${rmd}"))))
+  recordsToBeWritten.traverse_(r => p.sendAsync(r).flatMap(rmd => IO(println(s"Wrote record to ${rmd}"))))
 ).unsafeRunSync()
 ```
 


### PR DESCRIPTION
I discovered these while merging forward to 6.x and trying to remove the deprecated `sendSync`.