### PR TITLE
KAYAK-3361 commit offsets on stream finalization

### DIFF
--- a/core/src/main/scala/com/banno/kafka/consumer/ConsumerOps.scala
+++ b/core/src/main/scala/com/banno/kafka/consumer/ConsumerOps.scala
@@ -356,16 +356,13 @@ case class ConsumerOps[F[_], K, V](consumer: ConsumerApi[F, K, V]) {
   /** Returns a stream that processes records using the specified function,
     * committing offsets for successfully processed records, either after
     * processing the specified number of records, or after the specified time
-    * has elapsed since the last offset commit. If the processing function
-    * returns a failure, offsets for records successfully processed before that
-    * failure will be committed, and then the stream will halt with that
-    * failure. This is at-least-once processing: after a restart, the record
-    * that failed will be reprocessed. On successful stream finalization,
-    * offsets will also be committed. In some use cases this pattern is more
-    * appropriate than just using auto-offset-commits, since it will not commit
-    * offsets for failed records when the consumer is closed. The consumer must
-    * be configured to disable offset auto-commits, i.e.
-    * `enable.auto.commit=false`.
+    * has elapsed since the last offset commit. On any stream finalization,
+    * whether success, error, or cancelation, offsets will be committed. This is
+    * at-least-once processing: after a restart, the record that failed will be
+    * reprocessed. In some use cases this pattern is more appropriate than just
+    * using auto-offset-commits, since it will not commit offsets for failed
+    * records when the consumer is closed. The consumer must be configured to
+    * disable offset auto-commits, i.e. `enable.auto.commit=false`.
     */
   def processingAndCommitting[A](
       pollTimeout: FiniteDuration,

--- a/core/src/main/scala/com/banno/kafka/consumer/ConsumerOps.scala
+++ b/core/src/main/scala/com/banno/kafka/consumer/ConsumerOps.scala
@@ -353,8 +353,6 @@ case class ConsumerOps[F[_], K, V](consumer: ConsumerApi[F, K, V]) {
       .recordStream(pollTimeout)
       .evalMap(r => process(r) <* consumer.commitSync(r.nextOffset))
 
-  // TODO document commit on error & successful finalize
-
   /** Returns a stream that processes records using the specified function,
     * committing offsets for successfully processed records, either after
     * processing the specified number of records, or after the specified time
@@ -362,10 +360,12 @@ case class ConsumerOps[F[_], K, V](consumer: ConsumerApi[F, K, V]) {
     * returns a failure, offsets for records successfully processed before that
     * failure will be committed, and then the stream will halt with that
     * failure. This is at-least-once processing: after a restart, the record
-    * that failed will be reprocessed. In some use cases this pattern is more
+    * that failed will be reprocessed. On successful stream finalization,
+    * offsets will also be committed. In some use cases this pattern is more
     * appropriate than just using auto-offset-commits, since it will not commit
     * offsets for failed records when the consumer is closed. The consumer must
-    * be configured to disable offset auto-commits.
+    * be configured to disable offset auto-commits, i.e.
+    * `enable.auto.commit=false`.
     */
   def processingAndCommitting[A](
       pollTimeout: FiniteDuration,

--- a/core/src/main/scala/com/banno/kafka/consumer/ConsumerOps.scala
+++ b/core/src/main/scala/com/banno/kafka/consumer/ConsumerOps.scala
@@ -401,14 +401,7 @@ case class ConsumerOps[F[_], K, V](consumer: ConsumerApi[F, K, V]) {
                 )
             } yield a
           }
-          .onFinalizeCase {
-            case Resource.ExitCase.Succeeded =>
-              commitNextOffsets
-            case Resource.ExitCase.Errored(_) =>
-              commitNextOffsets
-            case Resource.ExitCase.Canceled =>
-              Applicative[F].unit
-          }
+          .onFinalize(commitNextOffsets)
       }
 
   case class OffsetCommitState(

--- a/core/src/main/scala/com/banno/kafka/consumer/ConsumerOps.scala
+++ b/core/src/main/scala/com/banno/kafka/consumer/ConsumerOps.scala
@@ -390,13 +390,12 @@ case class ConsumerOps[F[_], K, V](consumer: ConsumerApi[F, K, V]) {
           .recordStream(pollTimeout)
           .evalMap { record =>
             for {
-              a <- process(record) /*.onError(_ => commitNextOffsets)*/
+              a <- process(record)
               s <- state.updateAndGet(_.update(record))
               now <- C.monotonic
               () <- s
                 .needToCommit(maxRecordCount, now, maxElapsedTime)
                 .traverse_(os =>
-                  // TODO this is probably synchronously blocking a thread, and we should use commitAsync instead
                   commit(os) *>
                   state.update(_.reset(now))
                 )

--- a/core/src/main/scala/com/banno/kafka/consumer/ConsumerOps.scala
+++ b/core/src/main/scala/com/banno/kafka/consumer/ConsumerOps.scala
@@ -412,33 +412,6 @@ case class ConsumerOps[F[_], K, V](consumer: ConsumerApi[F, K, V]) {
           }
       }
 
-  // for {
-  //   state <- Stream.eval(
-  //     C.monotonic
-  //       .flatMap(now =>
-  //         Ref.of[F, OffsetCommitState](OffsetCommitState.empty(now))
-  //       )
-  //   )
-  //   record <- consumer.recordStream(pollTimeout)
-  //   a <- Stream.eval(
-  //     process(record)
-  //       .onError(_ =>
-  //         // we can still commit offsets that were successfully processed, before this stream halts, consumer is closed, etc
-  //         // this is still at-least-once processing, but minimizes the amount of reprocessing after restart
-  //         state.get.flatMap(s => consumer.commitSync(s.nextOffsets))
-  //       )
-  //   )
-  //   s <- Stream.eval(state.updateAndGet(_.update(record)))
-  //   now <- Stream.eval(C.monotonic)
-  //   () <- Stream.eval(
-  //     s.needToCommit(maxRecordCount, now, maxElapsedTime)
-  //       .traverse_(os =>
-  //         consumer.commitSync(os) *>
-  //         state.update(_.reset(now))
-  //       )
-  //   )
-  // } yield a
-
   case class OffsetCommitState(
       offsets: Map[TopicPartition, Long],
       recordCount: Long,

--- a/core/src/test/scala/com/banno/kafka/ProcessingAndCommittingSpec.scala
+++ b/core/src/test/scala/com/banno/kafka/ProcessingAndCommittingSpec.scala
@@ -38,188 +38,213 @@ class ProcessingAndCommittingSpec extends CatsEffectSuite with KafkaSpec {
 
   val empty = Map.empty[TopicPartition, OffsetAndMetadata]
 
-  test("processingAndCommitting commits after number of records") {
+  def producerResource =
     ProducerApi
       .resource[IO, Int, Int](
         BootstrapServers(bootstrapServer)
       )
-      .use { producer =>
-        ConsumerApi
-          .resource[IO, Int, Int](
-            BootstrapServers(bootstrapServer),
-            GroupId(genGroupId),
-            AutoOffsetReset.earliest,
-            EnableAutoCommit(false),
+
+  def consumerResource =
+    ConsumerApi
+      .resource[IO, Int, Int](
+        BootstrapServers(bootstrapServer),
+        GroupId(genGroupId),
+        AutoOffsetReset.earliest,
+        EnableAutoCommit(false),
+      )
+
+  test("processingAndCommitting commits after number of records") {
+    producerResource.use { producer =>
+      consumerResource.use { consumer =>
+        for {
+          topic <- createTestTopic[IO]()
+          p = new TopicPartition(topic, 0)
+          ps = Set(p)
+          values = (0 to 9).toList
+          _ <- producer.sendAsyncBatch(
+            values.map(v => new ProducerRecord(topic, v, v))
           )
-          .use { consumer =>
-            for {
-              topic <- createTestTopic[IO]()
-              p = new TopicPartition(topic, 0)
-              ps = Set(p)
-              values = (0 to 9).toList
-              _ <- producer.sendAsyncBatch(
-                values.map(v => new ProducerRecord(topic, v, v))
-              )
-              () <- consumer.subscribe(topic)
-              c0 <- consumer.partitionQueries.committed(ps)
-              pac = consumer.processingAndCommitting(
-                pollTimeout = 100.millis,
-                maxRecordCount = 2,
-                maxElapsedTime = Long.MaxValue.nanos,
-              )(_.value.pure[IO])
-              committed = Stream.repeatEval(
-                consumer.partitionQueries.committed(ps)
-              )
-              results <- pac
-                .take(values.size.toLong)
-                .interleave(committed)
-                .compile
-                .toList
-            } yield {
-              assertEquals(c0, empty)
-              assertEquals(results.size, values.size * 2)
-              // TODO rewrite this to use values, not so hard-coded
-              assertEquals(results(0), 0)
-              assertEquals(results(1), empty)
-              assertEquals(results(2), 1)
-              assertEquals(results(3), offsets(p, 2))
-              assertEquals(results(4), 2)
-              assertEquals(results(5), offsets(p, 2))
-              assertEquals(results(6), 3)
-              assertEquals(results(7), offsets(p, 4))
-              assertEquals(results(8), 4)
-              assertEquals(results(9), offsets(p, 4))
-              assertEquals(results(10), 5)
-              assertEquals(results(11), offsets(p, 6))
-              assertEquals(results(12), 6)
-              assertEquals(results(13), offsets(p, 6))
-              assertEquals(results(14), 7)
-              assertEquals(results(15), offsets(p, 8))
-              assertEquals(results(16), 8)
-              assertEquals(results(17), offsets(p, 8))
-              assertEquals(results(18), 9)
-              assertEquals(results(19), offsets(p, 10))
-            }
-          }
+          () <- consumer.subscribe(topic)
+          c0 <- consumer.partitionQueries.committed(ps)
+          pac = consumer.processingAndCommitting(
+            pollTimeout = 100.millis,
+            maxRecordCount = 2,
+            maxElapsedTime = Long.MaxValue.nanos,
+          )(_.value.pure[IO])
+          committed = Stream.repeatEval(
+            consumer.partitionQueries.committed(ps)
+          )
+          results <- pac
+            .take(values.size.toLong)
+            .interleave(committed)
+            .compile
+            .toList
+        } yield {
+          assertEquals(c0, empty)
+          assertEquals(results.size, values.size * 2)
+          // TODO rewrite this to use values, not so hard-coded
+          assertEquals(results(0), 0)
+          assertEquals(results(1), empty)
+          assertEquals(results(2), 1)
+          assertEquals(results(3), offsets(p, 2))
+          assertEquals(results(4), 2)
+          assertEquals(results(5), offsets(p, 2))
+          assertEquals(results(6), 3)
+          assertEquals(results(7), offsets(p, 4))
+          assertEquals(results(8), 4)
+          assertEquals(results(9), offsets(p, 4))
+          assertEquals(results(10), 5)
+          assertEquals(results(11), offsets(p, 6))
+          assertEquals(results(12), 6)
+          assertEquals(results(13), offsets(p, 6))
+          assertEquals(results(14), 7)
+          assertEquals(results(15), offsets(p, 8))
+          assertEquals(results(16), 8)
+          assertEquals(results(17), offsets(p, 8))
+          assertEquals(results(18), 9)
+          assertEquals(results(19), offsets(p, 10))
+        }
       }
+    }
   }
 
   // this has a real danger of becoming a "flaky test" due to its timing assumptions
   test("processingAndCommitting commits after elapsed time") {
-    ProducerApi
-      .resource[IO, Int, Int](
-        BootstrapServers(bootstrapServer)
-      )
-      .use { producer =>
-        ConsumerApi
-          .resource[IO, Int, Int](
-            BootstrapServers(bootstrapServer),
-            GroupId(genGroupId),
-            AutoOffsetReset.earliest,
-            EnableAutoCommit(false),
+    producerResource.use { producer =>
+      consumerResource.use { consumer =>
+        for {
+          topic <- createTestTopic[IO]()
+          p = new TopicPartition(topic, 0)
+          ps = Set(p)
+          values = (0 to 9).toList
+          _ <- producer.sendAsyncBatch(
+            values.map(v => new ProducerRecord(topic, v, v))
           )
-          .use { consumer =>
-            for {
-              topic <- createTestTopic[IO]()
-              p = new TopicPartition(topic, 0)
-              ps = Set(p)
-              values = (0 to 9).toList
-              _ <- producer.sendAsyncBatch(
-                values.map(v => new ProducerRecord(topic, v, v))
-              )
-              () <- consumer.subscribe(topic)
-              c0 <- consumer.partitionQueries.committed(ps)
-              pac = consumer.processingAndCommitting(
-                pollTimeout = 100.millis,
-                maxRecordCount = Long.MaxValue,
-                maxElapsedTime = 200.millis,
-              )(r => IO.sleep(101.millis).as(r.value))
-              committed = Stream.repeatEval(
-                consumer.partitionQueries.committed(ps)
-              )
-              results <- pac
-                .take(values.size.toLong)
-                .interleave(committed)
-                .compile
-                .toList
-            } yield {
-              assertEquals(c0, empty)
-              assertEquals(results.size, values.size * 2)
-              // TODO rewrite this to use values, not so hard-coded
-              assertEquals(results(0), 0)
-              assertEquals(results(1), empty)
-              assertEquals(results(2), 1)
-              assertEquals(results(3), offsets(p, 2))
-              assertEquals(results(4), 2)
-              assertEquals(results(5), offsets(p, 2))
-              assertEquals(results(6), 3)
-              assertEquals(results(7), offsets(p, 4))
-              assertEquals(results(8), 4)
-              assertEquals(results(9), offsets(p, 4))
-              assertEquals(results(10), 5)
-              assertEquals(results(11), offsets(p, 6))
-              assertEquals(results(12), 6)
-              assertEquals(results(13), offsets(p, 6))
-              assertEquals(results(14), 7)
-              assertEquals(results(15), offsets(p, 8))
-              assertEquals(results(16), 8)
-              assertEquals(results(17), offsets(p, 8))
-              assertEquals(results(18), 9)
-              assertEquals(results(19), offsets(p, 10))
-            }
-          }
+          () <- consumer.subscribe(topic)
+          c0 <- consumer.partitionQueries.committed(ps)
+          pac = consumer.processingAndCommitting(
+            pollTimeout = 100.millis,
+            maxRecordCount = Long.MaxValue,
+            maxElapsedTime = 200.millis,
+          )(r => IO.sleep(101.millis).as(r.value))
+          committed = Stream.repeatEval(
+            consumer.partitionQueries.committed(ps)
+          )
+          results <- pac
+            .take(values.size.toLong)
+            .interleave(committed)
+            .compile
+            .toList
+        } yield {
+          assertEquals(c0, empty)
+          assertEquals(results.size, values.size * 2)
+          // TODO rewrite this to use values, not so hard-coded
+          assertEquals(results(0), 0)
+          assertEquals(results(1), empty)
+          assertEquals(results(2), 1)
+          assertEquals(results(3), offsets(p, 2))
+          assertEquals(results(4), 2)
+          assertEquals(results(5), offsets(p, 2))
+          assertEquals(results(6), 3)
+          assertEquals(results(7), offsets(p, 4))
+          assertEquals(results(8), 4)
+          assertEquals(results(9), offsets(p, 4))
+          assertEquals(results(10), 5)
+          assertEquals(results(11), offsets(p, 6))
+          assertEquals(results(12), 6)
+          assertEquals(results(13), offsets(p, 6))
+          assertEquals(results(14), 7)
+          assertEquals(results(15), offsets(p, 8))
+          assertEquals(results(16), 8)
+          assertEquals(results(17), offsets(p, 8))
+          assertEquals(results(18), 9)
+          assertEquals(results(19), offsets(p, 10))
+        }
       }
+    }
   }
 
   case class CommitOnFailureException()
       extends RuntimeException("Commit on failure exception")
 
   test("on failure, commits successful offsets, but not the failed offset") {
-    ProducerApi
-      .resource[IO, Int, Int](
-        BootstrapServers(bootstrapServer)
-      )
-      .use { producer =>
-        ConsumerApi
-          .resource[IO, Int, Int](
-            BootstrapServers(bootstrapServer),
-            GroupId(genGroupId),
-            AutoOffsetReset.earliest,
-            EnableAutoCommit(false),
+    producerResource.use { producer =>
+      consumerResource.use { consumer =>
+        for {
+          topic <- createTestTopic[IO]()
+          p = new TopicPartition(topic, 0)
+          ps = Set(p)
+          values = (0 to 9).toList
+          throwOn = 7
+          _ <- producer.sendAsyncBatch(
+            values.map(v => new ProducerRecord(topic, v, v))
           )
-          .use { consumer =>
-            for {
-              topic <- createTestTopic[IO]()
-              p = new TopicPartition(topic, 0)
-              ps = Set(p)
-              values = (0 to 9).toList
-              throwOn = 7
-              _ <- producer.sendAsyncBatch(
-                values.map(v => new ProducerRecord(topic, v, v))
-              )
-              () <- consumer.subscribe(topic)
-              c0 <- consumer.partitionQueries.committed(ps)
-              pac = consumer.processingAndCommitting(
-                pollTimeout = 100.millis,
-                maxRecordCount = Long.MaxValue,
-                maxElapsedTime = Long.MaxValue.nanos,
-              ) { r =>
-                val v = r.value
-                if (v == throwOn)
-                  IO.raiseError(CommitOnFailureException())
-                else
-                  v.pure[IO]
-              }
-              results <- pac.compile.toList.attempt
-              c1 <- consumer.partitionQueries.committed(ps)
-            } yield {
-              assertEquals(c0, empty)
-              assertEquals(results, Left(CommitOnFailureException()))
-              // on failure, the committed offset should be the one that failed, so processing will resume there next time and try again
-              assertEquals(c1, offsets(p, throwOn.toLong))
-            }
+          () <- consumer.subscribe(topic)
+          c0 <- consumer.partitionQueries.committed(ps)
+          pac = consumer.processingAndCommitting(
+            pollTimeout = 100.millis,
+            maxRecordCount = Long.MaxValue,
+            maxElapsedTime = Long.MaxValue.nanos,
+          ) { r =>
+            val v = r.value
+            if (v == throwOn)
+              IO.raiseError(CommitOnFailureException())
+            else
+              v.pure[IO]
           }
+          results <- pac.compile.toList.attempt
+          c1 <- consumer.partitionQueries.committed(ps)
+        } yield {
+          assertEquals(c0, empty)
+          assertEquals(results, Left(CommitOnFailureException()))
+          // on failure, the committed offset should be the one that failed, so processing will resume there next time and try again
+          assertEquals(c1, offsets(p, throwOn.toLong))
+        }
       }
+    }
+  }
+
+  test("commits offsets on successful stream finalization") {
+    producerResource.use { producer =>
+      createTestTopic[IO]().flatMap { topic =>
+        val p = new TopicPartition(topic, 0)
+        val ps = Set(p)
+        val values = (0 to 9).toList
+        consumerResource.use { consumer =>
+          for {
+            // topic <- createTestTopic[IO]()
+            // p = new TopicPartition(topic, 0)
+            // ps = Set(p)
+            // values = (0 to 9).toList
+            _ <- producer.sendAsyncBatch(
+              values.map(v => new ProducerRecord(topic, v, v))
+            )
+            () <- consumer.subscribe(topic)
+            c0 <- consumer.partitionQueries.committed(ps)
+            pac = consumer.processingAndCommitting(
+              pollTimeout = 100.millis,
+              maxRecordCount = Long.MaxValue,
+              maxElapsedTime = Long.MaxValue.nanos,
+            )(_.value.pure[IO])
+            results <- pac.take(values.size.toLong).compile.toList
+            c1 <- consumer.partitionQueries.committed(ps)
+          } yield {
+            assertEquals(c0, empty)
+            assertEquals(results, values)
+            assertEquals(c1, offsets(p, 10))
+          }
+        } /**>
+        // previous consumer resource should be closed now, which should have committed consumer offsets
+        consumerResource.use { consumer =>
+          for {
+            () <- consumer.subscribe(topic)
+            c2 <- consumer.partitionQueries.committed(ps)
+          } yield {
+            assertEquals(c2, offsets(p, 10))
+          }
+        }*/
+      }
+    }
   }
 
 }

--- a/core/src/test/scala/com/banno/kafka/ProcessingAndCommittingSpec.scala
+++ b/core/src/test/scala/com/banno/kafka/ProcessingAndCommittingSpec.scala
@@ -233,16 +233,14 @@ class ProcessingAndCommittingSpec extends CatsEffectSuite with KafkaSpec {
             assertEquals(results, values)
             assertEquals(c1, offsets(p, 10))
           }
-        } /**>
-        // previous consumer resource should be closed now, which should have committed consumer offsets
-        consumerResource.use { consumer =>
-          for {
-            () <- consumer.subscribe(topic)
-            c2 <- consumer.partitionQueries.committed(ps)
-          } yield {
-            assertEquals(c2, offsets(p, 10))
-          }
-        }*/
+        }
+
+        /** > // previous consumer resource should be closed now, which should
+          * have committed consumer offsets consumerResource.use { consumer =>
+          * for { () <- consumer.subscribe(topic) c2 <-
+          * consumer.partitionQueries.committed(ps) } yield { assertEquals(c2,
+          * offsets(p, 10)) } }
+          */
       }
     }
   }

--- a/core/src/test/scala/com/banno/kafka/ProcessingAndCommittingSpec.scala
+++ b/core/src/test/scala/com/banno/kafka/ProcessingAndCommittingSpec.scala
@@ -233,7 +233,7 @@ class ProcessingAndCommittingSpec extends CatsEffectSuite with KafkaSpec {
     }
   }
 
-  test("commits offsets on stream cancel".only) {
+  test("commits offsets on stream cancel") {
     producerResource.use { producer =>
       consumerResource.use { consumer =>
         for {


### PR DESCRIPTION
[KAYAK-3361] Previously, we were only committing on the `process` function failing. Now we'll commit on any of the following:
- the stream halts successfully
- the stream halts due to an error in any of the effects
- the stream halts due to a cancelation

This should not violate at-least-once, as we'll only ever commit an offset that was successfully processed and never commit an offset that was not successfully processed. There is a chance that we won't commit an offset for a successfully processed record, but that's part of at-least-once.

This might lead to doing something "dumb" like committing after committing failed. This could be seen as a retry (probably followed by an app crash) or in a future PR we could try to avoid such things. But they should not affect correctness.

[KAYAK-3361]: https://banno-jha.atlassian.net/browse/KAYAK-3361?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ