### PR TITLE
KAYAK-3387 Most Consumer operations are blocking and interruptible

### DIFF
--- a/core/src/main/scala/com/banno/kafka/consumer/PartitionQueries.scala
+++ b/core/src/main/scala/com/banno/kafka/consumer/PartitionQueries.scala
@@ -115,10 +115,11 @@ object PartitionQueries {
 
   def apply[F[_]: Sync](c: Consumer[_, _]): PartitionQueries[F] =
     new PartitionQueries[F] {
+
       override def beginningOffsets(
           partitions: Iterable[TopicPartition]
       ): F[Map[TopicPartition, Long]] =
-        Sync[F].delay(
+        Sync[F].interruptible(
           c.beginningOffsets(partitions.asJavaCollection)
             .asScala
             .toMap
@@ -131,7 +132,7 @@ object PartitionQueries {
           partitions: Iterable[TopicPartition],
           timeout: FiniteDuration,
       ): F[Map[TopicPartition, Long]] =
-        Sync[F].delay(
+        Sync[F].interruptible(
           c.beginningOffsets(
             partitions.asJavaCollection,
             java.time.Duration.ofMillis(timeout.toMillis),
@@ -145,7 +146,7 @@ object PartitionQueries {
       override def committed(
           partitions: Set[TopicPartition]
       ): F[Map[TopicPartition, OffsetAndMetadata]] =
-        Sync[F].delay(
+        Sync[F].interruptible(
           c.committed(partitions.asJava)
             .asScala
             .filter(valueIsNotNull)
@@ -155,7 +156,7 @@ object PartitionQueries {
       override def endOffsets(
           partitions: Iterable[TopicPartition]
       ): F[Map[TopicPartition, Long]] =
-        Sync[F].delay(
+        Sync[F].interruptible(
           c.endOffsets(partitions.asJavaCollection)
             .asScala
             .toMap
@@ -163,11 +164,12 @@ object PartitionQueries {
             .mapValues(Long.unbox)
             .toMap
         )
+
       override def endOffsets(
           partitions: Iterable[TopicPartition],
           timeout: FiniteDuration,
       ): F[Map[TopicPartition, Long]] =
-        Sync[F].delay(
+        Sync[F].interruptible(
           c.endOffsets(
             partitions.asJavaCollection,
             java.time.Duration.ofMillis(timeout.toMillis),
@@ -181,18 +183,19 @@ object PartitionQueries {
       override def offsetsForTimes(
           timestampsToSearch: Map[TopicPartition, Long]
       ): F[Map[TopicPartition, OffsetAndTimestamp]] =
-        Sync[F].delay(
+        Sync[F].interruptible(
           c.offsetsForTimes(
             timestampsToSearch.view.mapValues(Long.box).toMap.asJava
           ).asScala
             .filter(valueIsNotNull)
             .toMap
         )
+
       override def offsetsForTimes(
           timestampsToSearch: Map[TopicPartition, Long],
           timeout: FiniteDuration,
       ): F[Map[TopicPartition, OffsetAndTimestamp]] =
-        Sync[F].delay(
+        Sync[F].interruptible(
           c.offsetsForTimes(
             timestampsToSearch.view.mapValues(Long.box).toMap.asJava,
             java.time.Duration.ofMillis(timeout.toMillis),
@@ -202,12 +205,13 @@ object PartitionQueries {
         )
 
       override def partitionsFor(topic: String): F[Seq[PartitionInfo]] =
-        Sync[F].delay(c.partitionsFor(topic).asScala.toSeq)
+        Sync[F].interruptible(c.partitionsFor(topic).asScala.toSeq)
+
       override def partitionsFor(
           topic: String,
           timeout: FiniteDuration,
       ): F[Seq[PartitionInfo]] =
-        Sync[F].delay(
+        Sync[F].interruptible(
           c.partitionsFor(topic, java.time.Duration.ofMillis(timeout.toMillis))
             .asScala
             .toSeq


### PR DESCRIPTION
[KAYAK-3387] These consumer operations are synchronous and blocking. The calling thread is blocked until results are returned. There may be some asynchronous I/O down underneath in the Java consumer, but we don't have access to it. These operations should thus be shifted to cats-effect's blocking context/thread pool, so that no threads in the compute pool are blocked.

This PR uses `interruptible` instead of just `blocking`. There is evidence that `Thread.interrupt` will actually interrupt/cancel the underlying operations.

Also removed some unneeded trace/debug logging from the consumer.

Reference: [CE3 thread model](https://typelevel.org/cats-effect/docs/thread-model).

[KAYAK-3387]: https://banno-jha.atlassian.net/browse/KAYAK-3387?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ