### PR TITLE
KAYAK-3409 Revert ConsumerImpl back to Sync[F].delay

### DIFF
--- a/core/src/main/scala/com/banno/kafka/consumer/ConsumerApi.scala
+++ b/core/src/main/scala/com/banno/kafka/consumer/ConsumerApi.scala
@@ -238,6 +238,12 @@ trait ConsumerApi[F[_], K, V] {
   }
 }
 
+/** Since the underlying Java KafkaConsumer is (as documented) *not*
+  * thread-safe, this can be used to shift all operations on to an execution
+  * context that makes this safe (e.g. a single-thread pool). Currently, this is
+  * the safest way to use ConsumerImpl, and is used in all ConsumerApi-creating
+  * operations below, that are used in practice.
+  */
 object ShiftingConsumer {
   def apply[F[_]: Async, K, V](
       c: ConsumerApi[F, K, V],

--- a/core/src/main/scala/com/banno/kafka/consumer/ConsumerImpl.scala
+++ b/core/src/main/scala/com/banno/kafka/consumer/ConsumerImpl.scala
@@ -28,46 +28,46 @@ case class ConsumerImpl[F[_], K, V](c: Consumer[K, V])(implicit F: Sync[F])
     extends ConsumerApi[F, K, V] {
 
   override def assign(partitions: Iterable[TopicPartition]): F[Unit] =
-    F.interruptible(c.assign(partitions.asJavaCollection))
+    F.delay(c.assign(partitions.asJavaCollection))
 
   override def assignment: F[Set[TopicPartition]] =
     F.delay(c.assignment().asScala.toSet)
 
   override def close: F[Unit] =
-    F.interruptible(c.close())
+    F.delay(c.close())
 
   override def close(timeout: FiniteDuration): F[Unit] =
-    F.interruptible(c.close(JDuration.ofMillis(timeout.toMillis)))
+    F.delay(c.close(JDuration.ofMillis(timeout.toMillis)))
 
   override def commitAsync: F[Unit] =
-    F.interruptible(c.commitAsync())
+    F.delay(c.commitAsync())
 
   override def commitAsync(
       offsets: Map[TopicPartition, OffsetAndMetadata],
       callback: OffsetCommitCallback,
   ): F[Unit] =
-    F.interruptible(c.commitAsync(offsets.asJava, callback))
+    F.delay(c.commitAsync(offsets.asJava, callback))
 
   override def commitAsync(callback: OffsetCommitCallback): F[Unit] =
-    F.interruptible(c.commitAsync(callback))
+    F.delay(c.commitAsync(callback))
 
   override def commitSync: F[Unit] =
-    F.interruptible(c.commitSync())
+    F.delay(c.commitSync())
 
   override def commitSync(
       offsets: Map[TopicPartition, OffsetAndMetadata]
   ): F[Unit] =
-    F.interruptible(c.commitSync(offsets.asJava))
+    F.delay(c.commitSync(offsets.asJava))
 
   override def listTopics: F[Map[String, Seq[PartitionInfo]]] =
-    F.interruptible(
+    F.delay(
       c.listTopics().asScala.toMap.view.mapValues(_.asScala.toSeq).toMap
     )
 
   override def listTopics(
       timeout: FiniteDuration
   ): F[Map[String, Seq[PartitionInfo]]] =
-    F.interruptible(
+    F.delay(
       c.listTopics(JDuration.ofMillis(timeout.toMillis))
         .asScala
         .toMap
@@ -80,54 +80,54 @@ case class ConsumerImpl[F[_], K, V](c: Consumer[K, V])(implicit F: Sync[F])
     F.delay(c.metrics().asScala.toMap)
 
   override def pause(partitions: Iterable[TopicPartition]): F[Unit] =
-    F.interruptible(c.pause(partitions.asJavaCollection))
+    F.delay(c.pause(partitions.asJavaCollection))
 
   override def paused: F[Set[TopicPartition]] =
     F.delay(c.paused().asScala.toSet)
 
   override def poll(timeout: FiniteDuration): F[ConsumerRecords[K, V]] =
-    F.interruptible(
+    F.delay(
       c.poll(JDuration.ofMillis(timeout.toMillis))
     )
 
   override def position(partition: TopicPartition): F[Long] =
-    F.interruptible(c.position(partition))
+    F.delay(c.position(partition))
 
   override def resume(partitions: Iterable[TopicPartition]): F[Unit] =
-    F.interruptible(c.resume(partitions.asJavaCollection))
+    F.delay(c.resume(partitions.asJavaCollection))
 
   override def seek(partition: TopicPartition, offset: Long): F[Unit] =
-    F.interruptible(c.seek(partition, offset))
+    F.delay(c.seek(partition, offset))
 
   override def seekToBeginning(partitions: Iterable[TopicPartition]): F[Unit] =
-    F.interruptible(c.seekToBeginning(partitions.asJavaCollection))
+    F.delay(c.seekToBeginning(partitions.asJavaCollection))
 
   override def seekToEnd(partitions: Iterable[TopicPartition]): F[Unit] =
-    F.interruptible(c.seekToEnd(partitions.asJavaCollection))
+    F.delay(c.seekToEnd(partitions.asJavaCollection))
 
   override def subscribe(topics: Iterable[String]): F[Unit] =
-    F.interruptible(c.subscribe(topics.asJavaCollection))
+    F.delay(c.subscribe(topics.asJavaCollection))
 
   override def subscribe(
       topics: Iterable[String],
       callback: ConsumerRebalanceListener,
   ): F[Unit] =
-    F.interruptible(c.subscribe(topics.asJavaCollection, callback))
+    F.delay(c.subscribe(topics.asJavaCollection, callback))
 
   override def subscribe(pattern: Pattern): F[Unit] =
-    F.interruptible(c.subscribe(pattern))
+    F.delay(c.subscribe(pattern))
 
   override def subscribe(
       pattern: Pattern,
       callback: ConsumerRebalanceListener,
   ): F[Unit] =
-    F.interruptible(c.subscribe(pattern, callback))
+    F.delay(c.subscribe(pattern, callback))
 
   override def subscription: F[Set[String]] =
     F.delay(c.subscription().asScala.toSet)
 
   override def unsubscribe: F[Unit] =
-    F.interruptible(c.unsubscribe())
+    F.delay(c.unsubscribe())
 
   override def partitionQueries: PartitionQueries[F] =
     PartitionQueries(c)

--- a/core/src/main/scala/com/banno/kafka/consumer/PartitionQueries.scala
+++ b/core/src/main/scala/com/banno/kafka/consumer/PartitionQueries.scala
@@ -119,7 +119,7 @@ object PartitionQueries {
       override def beginningOffsets(
           partitions: Iterable[TopicPartition]
       ): F[Map[TopicPartition, Long]] =
-        Sync[F].interruptible(
+        Sync[F].delay(
           c.beginningOffsets(partitions.asJavaCollection)
             .asScala
             .toMap
@@ -132,7 +132,7 @@ object PartitionQueries {
           partitions: Iterable[TopicPartition],
           timeout: FiniteDuration,
       ): F[Map[TopicPartition, Long]] =
-        Sync[F].interruptible(
+        Sync[F].delay(
           c.beginningOffsets(
             partitions.asJavaCollection,
             java.time.Duration.ofMillis(timeout.toMillis),
@@ -146,7 +146,7 @@ object PartitionQueries {
       override def committed(
           partitions: Set[TopicPartition]
       ): F[Map[TopicPartition, OffsetAndMetadata]] =
-        Sync[F].interruptible(
+        Sync[F].delay(
           c.committed(partitions.asJava)
             .asScala
             .filter(valueIsNotNull)
@@ -156,7 +156,7 @@ object PartitionQueries {
       override def endOffsets(
           partitions: Iterable[TopicPartition]
       ): F[Map[TopicPartition, Long]] =
-        Sync[F].interruptible(
+        Sync[F].delay(
           c.endOffsets(partitions.asJavaCollection)
             .asScala
             .toMap
@@ -169,7 +169,7 @@ object PartitionQueries {
           partitions: Iterable[TopicPartition],
           timeout: FiniteDuration,
       ): F[Map[TopicPartition, Long]] =
-        Sync[F].interruptible(
+        Sync[F].delay(
           c.endOffsets(
             partitions.asJavaCollection,
             java.time.Duration.ofMillis(timeout.toMillis),
@@ -183,7 +183,7 @@ object PartitionQueries {
       override def offsetsForTimes(
           timestampsToSearch: Map[TopicPartition, Long]
       ): F[Map[TopicPartition, OffsetAndTimestamp]] =
-        Sync[F].interruptible(
+        Sync[F].delay(
           c.offsetsForTimes(
             timestampsToSearch.view.mapValues(Long.box).toMap.asJava
           ).asScala
@@ -195,7 +195,7 @@ object PartitionQueries {
           timestampsToSearch: Map[TopicPartition, Long],
           timeout: FiniteDuration,
       ): F[Map[TopicPartition, OffsetAndTimestamp]] =
-        Sync[F].interruptible(
+        Sync[F].delay(
           c.offsetsForTimes(
             timestampsToSearch.view.mapValues(Long.box).toMap.asJava,
             java.time.Duration.ofMillis(timeout.toMillis),
@@ -205,13 +205,13 @@ object PartitionQueries {
         )
 
       override def partitionsFor(topic: String): F[Seq[PartitionInfo]] =
-        Sync[F].interruptible(c.partitionsFor(topic).asScala.toSeq)
+        Sync[F].delay(c.partitionsFor(topic).asScala.toSeq)
 
       override def partitionsFor(
           topic: String,
           timeout: FiniteDuration,
       ): F[Seq[PartitionInfo]] =
-        Sync[F].interruptible(
+        Sync[F].delay(
           c.partitionsFor(topic, java.time.Duration.ofMillis(timeout.toMillis))
             .asScala
             .toSeq


### PR DESCRIPTION
[KAYAK-3409] https://github.com/Banno/kafka4s/pull/835 was a terrible idea. It quickly led to `ConcurrentModificationException`, due to the non-thread-safe `KafkaConsumer` getting called concurrently by different threads of the cats-effect blocking pool.

We already account for this via `ShiftingConsumer`. There is likely ultimately a better way to handle this, but for now, `delay` remains.

[KAYAK-3409]: https://banno-jha.atlassian.net/browse/KAYAK-3409?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ