### PR TITLE
Upgrade Scala to 2.13.12; deprecate Topic.uncons and friends

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import laika.helium.config.HeliumIcon
 import laika.helium.config.IconLink
 import org.typelevel.sbt.site.GenericSiteSettings
 
-ThisBuild / scalaVersion := "2.13.10"
+ThisBuild / scalaVersion := "2.13.12"
 ThisBuild / crossScalaVersions := List(scalaVersion.value)
 ThisBuild / tlBaseVersion := "5.0"
 ThisBuild / tlMimaPreviousVersions ~= { versions =>

--- a/core/src/main/scala/com/banno/kafka/Publish.scala
+++ b/core/src/main/scala/com/banno/kafka/Publish.scala
@@ -45,6 +45,10 @@ object Publish {
     ): P
   }
 
+  @deprecated(
+    "Exists for Publish.toMany, which fails with a match error on a singleton topic.  Will be removed in 6.x.",
+    "5.0.6",
+  )
   object Builder {
     implicit def buildNPublishers[
         F[_]: MonadThrow,
@@ -77,6 +81,10 @@ object Publish {
       }
   }
 
+  @deprecated(
+    "Fails with a match error on a singleton topic.  Will be removed in 6.x.",
+    "5.0.6",
+  )
   def toMany[F[_], A <: Coproduct, B <: Coproduct](
       topics: Topics[A, B],
       producer: ProducerApi[F, GenericRecord, GenericRecord],

--- a/core/src/main/scala/com/banno/kafka/Topics.scala
+++ b/core/src/main/scala/com/banno/kafka/Topics.scala
@@ -133,10 +133,14 @@ object Topics {
     ): F[Unit] = tail.setUp(bootstrapServers, schemaRegistryUri, configs)
   }
 
+  @deprecated(
+    "Fails with a match error on a singleton topic.  Will be removed in 6.x.",
+    "5.0.6",
+  )
   def uncons[K, V, S <: Coproduct, T <: Coproduct](
       topics: Topics[IncomingRecord[K, V] :+: S, (K, V) :+: T]
   ): (Topic[K, V], Topics[S, T]) =
-    topics match {
+    (topics: @unchecked) match {
       case ConsTopics(topic, tail) => (topic, tail)
     }
 


### PR DESCRIPTION
`Publish.toMany` fails when called with a singleton topic.  I can't find any usages of this in the wild, so I propose deprecating the feature and dropping it in v6.

Includes the upgrade to Scala 2.13.12, which exposed the missing case.

Supersedes #783.