### PR TITLE
KAYAK-3391 RecordStream.processingAndCommitting

### DIFF
--- a/core/src/main/scala/com/banno/kafka/RecordStream.scala
+++ b/core/src/main/scala/com/banno/kafka/RecordStream.scala
@@ -213,8 +213,8 @@ object RecordStream {
           override protected def nextOffsets(x: A) = topical.nextOffset(x)
           override def records: Stream[F, A] = stream.records.flatMap(chunked)
           override def processingAndCommitting[B](
-              maxRecordCount: Long = 1000L,
-              maxElapsedTime: FiniteDuration = 60.seconds,
+              maxRecordCount: Long,
+              maxElapsedTime: FiniteDuration,
           )(
               process: A => F[B]
           ): Stream[F, B] =
@@ -544,8 +544,8 @@ object RecordStream {
             .prefetch
             .evalMap(parseBatch(topical))
         override def processingAndCommitting[C](
-            maxRecordCount: Long = 1000L,
-            maxElapsedTime: FiniteDuration = 60.seconds,
+            maxRecordCount: Long,
+            maxElapsedTime: FiniteDuration,
         )(
             process: IncomingRecords[A] => F[C]
         ): Stream[F, C] =

--- a/core/src/main/scala/com/banno/kafka/RecordStream.scala
+++ b/core/src/main/scala/com/banno/kafka/RecordStream.scala
@@ -46,6 +46,16 @@ sealed trait RecordStream[F[_], A] {
     */
   def readProcessCommit[B](process: A => F[B]): Stream[F, B]
 
+  /** Returns a stream that processes records using the specified function,
+    * committing offsets for successfully processed records, either after
+    * processing the specified number of records, or after the specified time
+    * has elapsed since the last offset commit. On any stream finalization,
+    * whether success, error, or cancelation, offsets will be committed. This is
+    * at-least-once processing: after a restart, the record that failed will be
+    * reprocessed. In some use cases this pattern is more appropriate than just
+    * using auto-offset-commits, since it will not commit offsets for failed
+    * records when the consumer is closed.
+    */
   def processingAndCommitting[B](
       maxRecordCount: Long = 1000L,
       maxElapsedTime: FiniteDuration = 60.seconds,

--- a/core/src/main/scala/com/banno/kafka/consumer/ConsumerOps.scala
+++ b/core/src/main/scala/com/banno/kafka/consumer/ConsumerOps.scala
@@ -380,15 +380,6 @@ case class ConsumerOps[F[_], K, V](consumer: ConsumerApi[F, K, V]) {
       r => Map(new TopicPartition(r.topic, r.partition) -> r.offset),
       _ => 1,
     )
-  // )(implicit T: Temporal[F]): Stream[F, A] =
-  // processingAndCommitting2[ConsumerRecord[K, V], A](
-  //   maxRecordCount.toInt,
-  //   maxElapsedTime,
-  // )(
-  //   consumer.recordStream(pollTimeout),
-  //   process,
-  //   r => Map(new TopicPartition(r.topic, r.partition) -> r.offset),
-  // )
 
   /** Returns a stream that processes batches of records using the specified
     * function, committing offsets for successfully processed batches, either
@@ -455,35 +446,6 @@ case class ConsumerOps[F[_], K, V](consumer: ConsumerApi[F, K, V]) {
           }
           .onFinalize(commitNextOffsets)
       }
-
-  /*
-  I think this impl based on Stream.groupWithin works, but the Bs are output in groups, instead of as As are processed
-  Not sure if this matters or not... at the very least, some tests would need to be rewritten
-  If A is a batch of records, groupWithin also groups by number of batches, not total count of records
-  For now, we're going to use our bespoke code, but may revisit groupWithin in the future
-   */
-  // def processingAndCommitting2[A, B](
-  //     maxRecordCount: Int,
-  //     maxElapsedTime: FiniteDuration,
-  // )(
-  //     stream: Stream[F, A],
-  //     process: A => F[B],
-  //     offsets: A => Map[TopicPartition, Long],
-  // )(implicit F: Temporal[F]): Stream[F, B] =
-  //   stream
-  //     .evalMap(a => process(a).map(b => (offsets(a), b)))
-  //     .groupWithin(maxRecordCount, maxElapsedTime)
-  //     .evalTap { c =>
-  //       val offsets = c.foldLeft(Map.empty[TopicPartition, Long])(_ ++ _._1)
-  //       val nextOffsets =
-  //         offsets.view.mapValues(o => new OffsetAndMetadata(o + 1)).toMap
-  //       println(
-  //         s"committing: values=${c.map(_._2).toList} offsets=$offsets, nextOffsets=$nextOffsets"
-  //       )
-  //       consumer.commitSync(nextOffsets)
-  //     }
-  //     .map(_.map(_._2))
-  //     .unchunks
 
   case class OffsetCommitState(
       offsets: Map[TopicPartition, Long],

--- a/core/src/main/scala/com/banno/kafka/consumer/ConsumerOps.scala
+++ b/core/src/main/scala/com/banno/kafka/consumer/ConsumerOps.scala
@@ -440,7 +440,7 @@ case class ConsumerOps[F[_], K, V](consumer: ConsumerApi[F, K, V]) {
   I think this impl based on Stream.groupWithin works, but the Bs are output in groups, instead of as As are processed
   Not sure if this matters or not... at the very least, some tests would need to be rewritten
   If A is a batch of records, groupWithin also groups by number of batches, not total count of records
-  */
+   */
   def processingAndCommitting2[A, B](
       maxRecordCount: Int,
       maxElapsedTime: FiniteDuration,
@@ -456,7 +456,9 @@ case class ConsumerOps[F[_], K, V](consumer: ConsumerApi[F, K, V]) {
         val offsets = c.foldLeft(Map.empty[TopicPartition, Long])(_ ++ _._1)
         val nextOffsets =
           offsets.view.mapValues(o => new OffsetAndMetadata(o + 1)).toMap
-        println(s"committing: values=${c.map(_._2).toList} offsets=$offsets, nextOffsets=$nextOffsets")
+        println(
+          s"committing: values=${c.map(_._2).toList} offsets=$offsets, nextOffsets=$nextOffsets"
+        )
         consumer.commitSync(nextOffsets)
       }
       .map(_.map(_._2))

--- a/core/src/main/scala/com/banno/kafka/consumer/ConsumerOps.scala
+++ b/core/src/main/scala/com/banno/kafka/consumer/ConsumerOps.scala
@@ -436,6 +436,32 @@ case class ConsumerOps[F[_], K, V](consumer: ConsumerApi[F, K, V]) {
           .onFinalize(commitNextOffsets)
       }
 
+  /*
+  I think this impl based on Stream.groupWithin works, but the Bs are output in groups, instead of as As are processed
+  Not sure if this matters or not... at the very least, some tests would need to be rewritten
+  If A is a batch of records, groupWithin also groups by number of batches, not total count of records
+  */
+  def processingAndCommitting2[A, B](
+      maxRecordCount: Int,
+      maxElapsedTime: FiniteDuration,
+  )(
+      stream: Stream[F, A],
+      process: A => F[B],
+      offsets: A => Map[TopicPartition, Long],
+  )(implicit F: Temporal[F]): Stream[F, B] =
+    stream
+      .evalMap(a => process(a).map(b => (offsets(a), b)))
+      .groupWithin(maxRecordCount, maxElapsedTime)
+      .evalTap { c =>
+        val offsets = c.foldLeft(Map.empty[TopicPartition, Long])(_ ++ _._1)
+        val nextOffsets =
+          offsets.view.mapValues(o => new OffsetAndMetadata(o + 1)).toMap
+        println(s"committing: values=${c.map(_._2).toList} offsets=$offsets, nextOffsets=$nextOffsets")
+        consumer.commitSync(nextOffsets)
+      }
+      .map(_.map(_._2))
+      .unchunks
+
   case class OffsetCommitState(
       offsets: Map[TopicPartition, Long],
       recordCount: Long,


### PR DESCRIPTION
[KAYAK-3391] Refactors `ConsumerOps.processingAndCommitting` to be very generic. Also adds a batched implementation.

Adds `processingAndCommitting` to the `RecordStream` abstraction, and implements it for both chunked (i.e. one-at-a-time) and batched record streams.

Note that batched `processingAndCommitting` simply processes the entire batch, and if that succeeds then it updates the state to include that successfully processed batch's offsets. Only offsets for records in successfully processed batches will be committed. It does not try to do fancy things like handle partially succeeding (and failing) batches, or try to update state with individual records' offsets as they are processed. Note that if a batch fails processing, none of the offsets in that batch will be committed. This will lead to more reprocessing after startup, but hey this is at-least-once and your processing is idempotent, _right_?

[KAYAK-3391]: https://banno-jha.atlassian.net/browse/KAYAK-3391?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ