### PR TITLE
Add publisher that can batch sends with fs2.Stream

### DIFF
--- a/core/src/main/scala/com/banno/kafka/publish/Publish.scala
+++ b/core/src/main/scala/com/banno/kafka/publish/Publish.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.banno.kafka
+package com.banno.kafka.publish
 
 import cats.*
 import cats.syntax.all.*

--- a/core/src/main/scala/com/banno/kafka/publish/PublishStream.scala
+++ b/core/src/main/scala/com/banno/kafka/publish/PublishStream.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019 Jack Henry & Associates, Inc.®
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.banno.kafka.publish
+
+import cats.*
+import cats.syntax.all.*
+import com.banno.kafka.Topical
+import com.banno.kafka.producer.ProducerApi
+import fs2.Pipe
+import org.apache.avro.generic.GenericRecord
+import org.apache.kafka.clients.producer.RecordMetadata
+
+object PublishStream {
+  type T[F[_], A] = Pipe[F, A, F[RecordMetadata]]
+  type KV[F[_], K, V] = T[F, (K, V)]
+
+  /** Makes a stream capable of publishing records in batches or sequentially.
+    * Batch size will depend on the size of the underlying chunks in the stream.
+    */
+
+  def to[F[_]: MonadThrow, A, B](
+      topical: Topical[A, B],
+      producer: ProducerApi[F, GenericRecord, GenericRecord],
+  ): T[F, B] = kv =>
+    kv
+      .evalMapChunk(b => topical.coparse(b).liftTo[F])
+      .evalMapChunk(r => producer.send(r))
+
+}

--- a/core/src/main/scala/com/banno/kafka/publish/PublishStreamOps.scala
+++ b/core/src/main/scala/com/banno/kafka/publish/PublishStreamOps.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019 Jack Henry & Associates, Inc.®
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.banno.kafka.publish
+
+import cats.Applicative
+import cats.effect.Concurrent
+import fs2.Stream
+
+final class PublishStreamOps[F[_], A](private val stream: Stream[F, F[A]])
+    extends AnyVal {
+
+  def batched(implicit A: Applicative[F]): Stream[F, A] =
+    stream.evalMapChunk(identity)
+
+  def parBatched(maxConcurrent: Int)(implicit C: Concurrent[F]): Stream[F, A] =
+    if (maxConcurrent > 0) stream.parEvalMap(maxConcurrent)(identity)
+    else stream.parEvalMapUnbounded(identity)
+
+  def parBatchedUnbounded(implicit C: Concurrent[F]): Stream[F, A] =
+    stream.parEvalMapUnbounded(identity)
+
+}

--- a/core/src/main/scala/com/banno/kafka/publish/package.scala
+++ b/core/src/main/scala/com/banno/kafka/publish/package.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019 Jack Henry & Associates, Inc.®
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.banno.kafka
+import fs2.Stream
+
+package object publish {
+
+  implicit def publishStreamOps[F[_], A](
+      stream: Stream[F, F[A]]
+  ): PublishStreamOps[F, A] =
+    new PublishStreamOps[F, A](stream)
+
+}


### PR DESCRIPTION
this should help prevent needing to bubble the topic all the way down to the callsite if one wants to send batched records via stream