### PR TITLE
Added batching producer ops

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Start docker-compose
         id: start-docker-compose
-        run: docker-compose up -d
+        run: docker compose up -d
 
       - name: Check that workflows are up to date
         run: sbt githubWorkflowCheck

--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ ThisBuild / githubWorkflowBuildPreamble := Seq(
   WorkflowStep.Run(
     id = Some("start-docker-compose"),
     name = Some("Start docker-compose"),
-    commands = List("docker-compose up -d"),
+    commands = List("docker compose up -d"),
   )
 )
 ThisBuild / tlSonatypeUseLegacyHost := true

--- a/core/src/main/scala/com/banno/kafka/producer/ProducerOps.scala
+++ b/core/src/main/scala/com/banno/kafka/producer/ProducerOps.scala
@@ -53,6 +53,18 @@ case class ProducerOps[F[_], K, V](producer: ProducerApi[F, K, V]) {
     } yield rms
   }
 
+  def sendBatchWithCallbacks[G[_]: Traverse](
+      records: G[ProducerRecord[K, V]],
+      onSend: ProducerRecord[K, V] => F[Unit],
+  )(implicit F: Monad[F]): F[G[RecordMetadata]] = {
+    val sends: G[F[F[RecordMetadata]]] =
+      records.map(r => producer.send(r) <* onSend(r))
+    for {
+      acks <- sends.sequence
+      rms <- acks.sequence
+    } yield rms
+  }
+
   def pipeSync: Pipe[F, ProducerRecord[K, V], RecordMetadata] =
     _.evalMap(producer.sendSync)
 
@@ -71,7 +83,9 @@ case class ProducerOps[F[_], K, V](producer: ProducerApi[F, K, V]) {
     s =>
       pipeSendBatch[Chunk](Traverse[Chunk], F)(s.chunks).flatMap(Stream.chunk)
 
-  /** Calls chunkN on the input stream, to create chunks of size `n`, and sends those chunks as batches to the producer. */
+  /** Calls chunkN on the input stream, to create chunks of size `n`, and sends
+    * those chunks as batches to the producer.
+    */
   def pipeSendBatchChunkN(n: Int, allowFewer: Boolean = true)(implicit
       F: Monad[F]
   ): Pipe[F, ProducerRecord[K, V], RecordMetadata] =

--- a/core/src/main/scala/com/banno/kafka/producer/ProducerOps.scala
+++ b/core/src/main/scala/com/banno/kafka/producer/ProducerOps.scala
@@ -35,14 +35,60 @@ case class ProducerOps[F[_], K, V](producer: ProducerApi[F, K, V]) {
   )(implicit F: Applicative[F]): F[G[RecordMetadata]] =
     records.traverse(producer.sendAsync)
 
+  /** Sends all of the records to the producer (synchronously), so the producer
+    * may batch them. After all records are sent, asynchronously waits for all
+    * acks. Returns the write metadatas, in order. This is the only batch write
+    * operation that allows the producer to perform its own batching, while
+    * semantically blocking until all writes have succeeded. It maximizes
+    * concurrency and producer batching, and also simplicity of usage. Fails if
+    * any individual send or ack fails.
+    */
+  def sendBatch[G[_]: Traverse](
+      records: G[ProducerRecord[K, V]]
+  )(implicit F: Monad[F]): F[G[RecordMetadata]] = {
+    val sends: G[F[F[RecordMetadata]]] = records.map(producer.send)
+    for {
+      acks <- sends.sequence
+      rms <- acks.sequence
+    } yield rms
+  }
+
+  def pipeSync: Pipe[F, ProducerRecord[K, V], RecordMetadata] =
+    _.evalMap(producer.sendSync)
+
   def pipeAsync: Pipe[F, ProducerRecord[K, V], RecordMetadata] =
     _.evalMap(producer.sendAsync)
+
+  def pipeSendBatch[G[_]: Traverse](implicit
+      F: Monad[F]
+  ): Pipe[F, G[ProducerRecord[K, V]], G[RecordMetadata]] =
+    _.evalMap(sendBatch[G])
+
+  /** Uses the stream's chunks as batches of records to send to the producer. */
+  def pipeSendBatchChunks(implicit
+      F: Monad[F]
+  ): Pipe[F, ProducerRecord[K, V], RecordMetadata] =
+    s =>
+      pipeSendBatch[Chunk](Traverse[Chunk], F)(s.chunks).flatMap(Stream.chunk)
+
+  /** Calls chunkN on the input stream, to create chunks of size `n`, and sends those chunks as batches to the producer. */
+  def pipeSendBatchChunkN(n: Int, allowFewer: Boolean = true)(implicit
+      F: Monad[F]
+  ): Pipe[F, ProducerRecord[K, V], RecordMetadata] =
+    s =>
+      pipeSendBatch[Chunk](Traverse[Chunk], F)(s.chunkN(n, allowFewer))
+        .flatMap(Stream.chunk)
 
   def sink: Pipe[F, ProducerRecord[K, V], Unit] =
     _.evalMap(producer.sendAndForget)
 
   def sinkAsync: Pipe[F, ProducerRecord[K, V], Unit] =
     pipeAsync.apply(_).void
+
+  def sinkSendBatch[G[_]: Traverse](implicit
+      F: Monad[F]
+  ): Pipe[F, G[ProducerRecord[K, V]], Unit] =
+    pipeSendBatch.apply(_).void
 
   def transaction[G[_]: Foldable](
       records: G[ProducerRecord[K, V]]

--- a/core/src/main/scala/com/banno/kafka/producer/ProducerOps.scala
+++ b/core/src/main/scala/com/banno/kafka/producer/ProducerOps.scala
@@ -53,6 +53,16 @@ case class ProducerOps[F[_], K, V](producer: ProducerApi[F, K, V]) {
     } yield rms
   }
 
+  def sendBatchNonEmpty[G[_]: NonEmptyTraverse](
+      records: G[ProducerRecord[K, V]]
+  )(implicit F: FlatMap[F]): F[G[RecordMetadata]] = {
+    val sends: G[F[F[RecordMetadata]]] = records.map(producer.send)
+    for {
+      acks <- sends.nonEmptySequence
+      rms <- acks.nonEmptySequence
+    } yield rms
+  }
+
   def sendBatchWithCallbacks[G[_]: Traverse](
       records: G[ProducerRecord[K, V]],
       onSend: ProducerRecord[K, V] => F[Unit],
@@ -62,6 +72,18 @@ case class ProducerOps[F[_], K, V](producer: ProducerApi[F, K, V]) {
     for {
       acks <- sends.sequence
       rms <- acks.sequence
+    } yield rms
+  }
+
+  def sendBatchWithCallbacks[G[_]: NonEmptyTraverse](
+      records: G[ProducerRecord[K, V]],
+      onSend: ProducerRecord[K, V] => F[Unit],
+  )(implicit F: FlatMap[F]): F[G[RecordMetadata]] = {
+    val sends: G[F[F[RecordMetadata]]] =
+      records.map(r => producer.send(r) <* onSend(r))
+    for {
+      acks <- sends.nonEmptySequence
+      rms <- acks.nonEmptySequence
     } yield rms
   }
 
@@ -75,6 +97,11 @@ case class ProducerOps[F[_], K, V](producer: ProducerApi[F, K, V]) {
       F: Monad[F]
   ): Pipe[F, G[ProducerRecord[K, V]], G[RecordMetadata]] =
     _.evalMap(sendBatch[G])
+
+  def pipeSendBatchNonEmpty[G[_]: NonEmptyTraverse](implicit
+      F: FlatMap[F]
+  ): Pipe[F, G[ProducerRecord[K, V]], G[RecordMetadata]] =
+    _.evalMap(sendBatchNonEmpty[G])
 
   /** Uses the stream's chunks as batches of records to send to the producer. */
   def pipeSendBatchChunks(implicit
@@ -103,6 +130,11 @@ case class ProducerOps[F[_], K, V](producer: ProducerApi[F, K, V]) {
       F: Monad[F]
   ): Pipe[F, G[ProducerRecord[K, V]], Unit] =
     pipeSendBatch.apply(_).void
+
+  def sinkSendBatch[G[_]: NonEmptyTraverse](implicit
+      F: FlatMap[F]
+  ): Pipe[F, G[ProducerRecord[K, V]], Unit] =
+    pipeSendBatchNonEmpty.apply(_).void
 
   def sinkSendBatchChunks(implicit
       F: Monad[F]

--- a/core/src/main/scala/com/banno/kafka/producer/ProducerOps.scala
+++ b/core/src/main/scala/com/banno/kafka/producer/ProducerOps.scala
@@ -17,6 +17,7 @@
 package com.banno.kafka.producer
 
 import cats.*
+import cats.data.NonEmptyList
 import cats.syntax.all.*
 import fs2.*
 import org.apache.kafka.common.*
@@ -109,6 +110,14 @@ case class ProducerOps[F[_], K, V](producer: ProducerApi[F, K, V]) {
   ): Pipe[F, ProducerRecord[K, V], RecordMetadata] =
     s =>
       pipeSendBatch[Chunk](Traverse[Chunk], F)(s.chunks).flatMap(Stream.chunk)
+
+  def pipeSendBatchChunksNonEmpty(implicit
+      F: FlatMap[F]
+  ): Pipe[F, ProducerRecord[K, V], RecordMetadata] =
+    s =>
+      pipeSendBatchNonEmpty[NonEmptyList](NonEmptyTraverse[NonEmptyList], F)(
+        s.chunks.map(_.toNel).unNone
+      ).flatMap(nel => Stream.emits(nel.toList))
 
   /** Calls chunkN on the input stream, to create chunks of size `n`, and sends
     * those chunks as batches to the producer.

--- a/core/src/main/scala/com/banno/kafka/producer/ProducerOps.scala
+++ b/core/src/main/scala/com/banno/kafka/producer/ProducerOps.scala
@@ -104,6 +104,16 @@ case class ProducerOps[F[_], K, V](producer: ProducerApi[F, K, V]) {
   ): Pipe[F, G[ProducerRecord[K, V]], Unit] =
     pipeSendBatch.apply(_).void
 
+  def sinkSendBatchChunks(implicit
+      F: Monad[F]
+  ): Pipe[F, ProducerRecord[K, V], Unit] =
+    pipeSendBatchChunks.apply(_).void
+
+  def sinkSendBatchChunkN(n: Int, allowFewer: Boolean = true)(implicit
+      F: Monad[F]
+  ): Pipe[F, ProducerRecord[K, V], Unit] =
+    pipeSendBatchChunkN(n, allowFewer).apply(_).void
+
   def transaction[G[_]: Foldable](
       records: G[ProducerRecord[K, V]]
   )(implicit F: MonadError[F, Throwable]): F[Unit] =

--- a/core/src/main/scala/com/banno/kafka/producer/ProducerOps.scala
+++ b/core/src/main/scala/com/banno/kafka/producer/ProducerOps.scala
@@ -88,9 +88,6 @@ case class ProducerOps[F[_], K, V](producer: ProducerApi[F, K, V]) {
     } yield rms
   }
 
-  def pipeSync: Pipe[F, ProducerRecord[K, V], RecordMetadata] =
-    _.evalMap(producer.sendSync)
-
   def pipeAsync: Pipe[F, ProducerRecord[K, V], RecordMetadata] =
     _.evalMap(producer.sendAsync)
 


### PR DESCRIPTION
Continuation of #825.

Added several batched send, pipe and sink convenience methods to `ProducerOps`.