### PR TITLE
keep-alive off-by-1 with no new records

### DIFF
--- a/core/src/main/scala/com/banno/kafka/consumer/ConsumerOps.scala
+++ b/core/src/main/scala/com/banno/kafka/consumer/ConsumerOps.scala
@@ -525,7 +525,7 @@ case class ConsumerOps[F[_], K, V](consumer: ConsumerApi[F, K, V]) {
                   for {
                     lock <- Semaphore(1)
                     ref <- Ref.of(
-                      offsets.view.mapValues(_.offset).toMap
+                      offsets.view.mapValues(_.offset - 1).toMap
                     )
                   } yield HasKeepAlive(interval0, lock, ref)
             } yield keepAlive

--- a/core/src/test/scala/com/banno/kafka/ProcessingAndCommittingSpec.scala
+++ b/core/src/test/scala/com/banno/kafka/ProcessingAndCommittingSpec.scala
@@ -568,4 +568,29 @@ class ProcessingAndCommittingSpec extends CatsEffectSuite with KafkaSpec {
       } yield ()
     }
   }
+
+  test("keepalive stream commits correct offset after no new records".only) {
+    consumerResource().use { consumer =>
+      for {
+        topic <- createTestTopic[IO]()
+        p = new TopicPartition(topic, 0)
+        ps = Set(p)
+        _ <- consumer.assign(ps)
+        c0 <- consumer.partitionQueries.committed(ps)
+        () <- consumer.commitSync(Map(p -> new OffsetAndMetadata(0)))
+        pac = consumer.processingAndCommitting(
+          pollTimeout = 100.millis,
+          maxRecordCount = Long.MaxValue,
+          maxElapsedTime = Long.MaxValue.nanos,
+          keepAliveInterval = 1.second,
+        )(_.value.pure[IO]).interruptAfter(3.seconds)
+        results <- pac.compile.toList
+        c1 <- consumer.partitionQueries.committed(ps)
+      } yield {
+        assert(c0.isEmpty)
+        assert(results.isEmpty)
+        assertEquals(c1(p).offset, 0L)
+      }
+  }}
+
 }

--- a/core/src/test/scala/com/banno/kafka/ProcessingAndCommittingSpec.scala
+++ b/core/src/test/scala/com/banno/kafka/ProcessingAndCommittingSpec.scala
@@ -569,7 +569,7 @@ class ProcessingAndCommittingSpec extends CatsEffectSuite with KafkaSpec {
     }
   }
 
-  test("keepalive stream commits correct offset after no new records".only) {
+  test("keepalive stream commits correct offset after no new records") {
     consumerResource().use { consumer =>
       for {
         topic <- createTestTopic[IO]()


### PR DESCRIPTION
`KeepAlive` was using the committed offsets as a starting point, which are already +1'ed into "next offsets". If no records are read from a partition, when keep-alive committed again, they were +1'ed again, 1 past the partition's end offset. On next program start, seeking to this offset resulted in a `org.apache.kafka.clients.consumer.OffsetOutOfRangeException`.

Solution is to `-1` those committed offsets, to bring them back into the space of "offsets of successfully processed records".