### PR TITLE
update tlBaseVersion to 6.1.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ import org.typelevel.sbt.site.GenericSiteSettings
 
 ThisBuild / scalaVersion := "2.13.15"
 ThisBuild / crossScalaVersions := List(scalaVersion.value)
-ThisBuild / tlBaseVersion := "6.0"
+ThisBuild / tlBaseVersion := "6.1.0"
 ThisBuild / githubWorkflowJavaVersions := Seq(JavaSpec.temurin("11"))
 ThisBuild / githubWorkflowTargetBranches := Seq("*", "series/*")
 ThisBuild / githubWorkflowBuildPreamble := Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ import org.typelevel.sbt.site.GenericSiteSettings
 
 ThisBuild / scalaVersion := "2.13.15"
 ThisBuild / crossScalaVersions := List(scalaVersion.value)
-ThisBuild / tlBaseVersion := "6.1.0"
+ThisBuild / tlBaseVersion := "6.1"
 ThisBuild / githubWorkflowJavaVersions := Seq(JavaSpec.temurin("11"))
 ThisBuild / githubWorkflowTargetBranches := Seq("*", "series/*")
 ThisBuild / githubWorkflowBuildPreamble := Seq(


### PR DESCRIPTION
The build for https://github.com/Banno/kafka4s/pull/949 is currently [failing](https://github.com/Banno/kafka4s/actions/runs/12559030288/job/35014117860?pr=949) with:

```
java.lang.RuntimeException: Your tlBaseVersion 6.0 is behind the latest tag 6.1.0
```